### PR TITLE
Fix quality issues in Benhabib_et_al_2019 assembly

### DIFF
--- a/models/We-Would-Like-In-Econ-ARK/Benhabib_et_al_2019/Benhabib_et_al_2019_digest.ipynb
+++ b/models/We-Would-Like-In-Econ-ARK/Benhabib_et_al_2019/Benhabib_et_al_2019_digest.ipynb
@@ -1,174 +1,173 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Benhabib, Bisin, and Luo\n",
-    "\n",
-    "## Weath Distribution and Social Mobility in the U.S.: A Quantitative Approach (AER 2019)\n",
-    "\n",
-    "**Updated by:** AI Demo (Johns Hopkins University) — 2026-01-27\n",
-    "\n",
-    "#### Summary"
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Wealth Distribution and Social Mobility in the U.S.: A Quantitative Approach\n",
+        "\n",
+        "Benhabib, Bisin, and Luo (AER 2019)\n",
+        "\n",
+        "## Summary"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "This paper presents a comprehensive analysis of the factors influencing wealth dynamics and social mobility in the United States. Key findings include:\n",
+        "\n",
+        "The main findings are listed below:\n",
+        "\n",
+        "- Motivation: Wealth is unequally distributed, with significant skewness and a thick right tail, where the top 1% holds a disproportionately large share of wealth {cite:p}`saez2016,piketty2014`.\n",
+        "- The lifecycle model developed in the study identifies three main factors driving these outcomes: skewed earnings distribution, differential savings rates across wealth levels, and stochastic idiosyncratic returns to wealth. All three factors are crucial for matching the observed wealth distribution and mobility patterns.\n",
+        "- The model developed matches empirical data well, and counterfactuals provide insights into the relative importance of the above factors in driving the wealth accumulation and distribution in the US.\n",
+        "\n",
+        "For a detailed discussion of the foundational literature this paper builds on, see the companion [Prior Literature](Benhabib_et_al_2019_prior-literature.ipynb) notebook."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Non-Technical Methodological Overview\n",
+        "\n",
+        "The paper develops a macroeconomic model to explore wealth accumulation, distribution, and social mobility in the U.S., focusing on three main forces:\n",
+        "\n",
+        "1. Stochastic Earnings: A large literature in the context of Aiyagari-Bewley economies has shown that income variability plays a key role in wealth inequality, affecting saving decisions and consumption patterns, particularly for the bottom 60% of households {cite:p}`aiyagari1994,castaneda2003`. However, it does not account for the wealth concentration among the wealthiest.\n",
+        "\n",
+        "2. Heterogeneous Rate of Return: Studies have identified significant variations in the risk-adjusted returns on investments across households, contributing to the wealth distribution's long tail {cite:p}`fagereng2020,quadrini2000,cagetti2006`. This variation is consistent over time and linked with entrepreneurial activity. The theoretical foundations for this channel were laid by {cite:t}`benhabib2011`.\n",
+        "\n",
+        "3. Differential saving rates across wealth levels: The model includes increasing bequest motives with wealth, suggesting a stronger saving motive among the wealthiest, who aim to leave significant assets for their heirs {cite:p}`denardi2004`. This perpetuates the transfer of large estates through generations.\n",
+        "\n",
+        "The analysis finds that stochastic earnings, differential savings, and capital income risk critically shape the wealth distribution's tail and social mobility. Capital income risk and differential savings widen the wealth distribution's tail and influence mobility, particularly enhancing it at the top end but reducing upward mobility from the bottom 20%. Despite being less impactful in the tail, stochastic earnings are vital for overall wealth mobility. Additionally, their findings suggest a wealth-dependent return rate enhances model fit across the wealth distribution. The stochastic process for returns which best fits the data shares statistical properties with those uncovered by {cite:t}`fagereng2020` from Norwegian tax records.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## The Model\n",
+        "\n",
+        "A fairly simple microfounded model of lifecycle consumption and savings. Each agent's life span is finite and deterministic, T years. \n",
+        "\n",
+        "### Features of the model\n",
+        "\n",
+        "1. Every period agents choose how much to consume ($c_t$) and save ($a_t$) out of their market resources.\n",
+        "2. All agents are subjected to a no borrowing constraint.\n",
+        "3. Agents leave bequests $a_{T}$ at the end of life T.\n",
+        "4. Wealth accumulates from savings and bequests.\n",
+        "5. Every agent is assigned an idiosyncratic rate of return r and life-time labor earnings profile $\\left\\{w_{t} \\right\\}_{t=1}^{T}$ possibly correlated with those of the parent. \n",
+        "6. Rate of return and earnings are stochastic across generations but deterministic within generation.\n",
+        "\n",
+        "### Preferences\n",
+        "Preferences are composed of:\n",
+        "1. per period utility from consumption\n",
+        "2. warm-glow utility  from bequests at T, $e(a_{T})$\n",
+        "$$\n",
+        "\\begin{aligned}\n",
+        "& u(c_t) = \\frac{c_{t}^{1 - \\sigma}}{1 - \\sigma}, \\quad \\quad e(a_t) = A\\frac{a_{T}^{1 - \\mu}}{1 - \\mu} \\\\\n",
+        "\\end{aligned}\n",
+        "$$\n",
+        "\n",
+        "### Recursive Formulation\n",
+        "Given initial wealth $a_0$, earnings profile and rate of return, each agent's optimization problem is:\n",
+        "$$\n",
+        "\\begin{aligned}\n",
+        "& V_{t}(a) = \\max_{c, a'} u(c) + \\beta V_{t+1}(a') \\\\\n",
+        "& \\text{s.t.c} \\\\\n",
+        "& a' = (1+r)a - c + w \\\\\n",
+        "& 0 \\leq c \\leq a, \\quad t = 1,..., T-1\\\\\n",
+        "& V_{T}(a) = u(c) + e(a')\\\\\n",
+        "\\end{aligned}\n",
+        "$$\n",
+        "\n",
+        "The solution to the above problem is a stochastic difference equation for the initial wealth of dynasties, induced by the $\\left\\{r^n, w^n \\right\\}_{n}$, mapping $a^{n-1}$ into $\\left\\{a^{n} \\right\\}_{n}$, where superscript correspond to the nth generation.\n",
+        "$$\n",
+        "\\begin{aligned}\n",
+        "& a^{n} = g(a^{n-1}; r^{n}, w^{n}) \\\\\n",
+        "\\end{aligned}\n",
+        "$$\n",
+        "\n",
+        "Under the given assumptions of the model, the following holds:\n",
+        "1. If $\\mu  = \\sigma$ $\\implies$ the stochastic process $\\left\\{a^{n} \\right\\}_{n}$ has a stationary distribution\n",
+        "2. If $\\mu  < \\sigma$ $\\implies$  savings rate increases with wealth (stationary dist. might not exist). If it does exist, then it displays a thick tail.\n",
+        "\n",
+        "### Quantitative Analysis\n",
+        "\n",
+        "The paper uses method of simulated moments (MSM) to identify unknown parameters.\n",
+        "\n",
+        "1. Externally calibrate some parameters of the model\n",
+        "2. Estimate remaining parameters of the model by matching the targeted moments generated by the stationary distribution induced by the model and those in the data\n",
+        "\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Results\n",
+        "\n",
+        "At the estimated parameter values, the model induced wealth distribution closely resembles the wealth distribution in the data.\n",
+        "-  The estimates point to the existence of differential saving behavior (bequest motives)\n",
+        "- Capital income risk an important factor in driving wealth inequality\n",
+        "\n",
+        "Next, paper shuts down each of the three main factors listed above. The objective of this counterfactual exercise is to gauge the relative importance of the three mechanisms in driving the distribution of wealth.\n",
+        "\n",
+        "### Counterfactual Summary\n",
+        "\n",
+        " 1. No rate of return heterogeneity $\\implies$ higher bequest motive (A doubles relative to baseline) & model can't match the upper tail of the wealth distribution (Table-15-row(3))\n",
+        "\n",
+        "\n",
+        " 2. No stochastic earnings $\\implies$ relative preference for bequests $\\uparrow$ while nothing else changes substantially & model does not miss as much in mimicking the upper tail of the wealth distribution $\\implies$ stochastic earnings not driving the behavior of the right-tail of wealth distribution. \n",
+        "    - However, social mobility matrix fit implied by this counterfactual is bad $\\implies$ stochastic earnings matter for social mobility\n",
+        "\n",
+        "\n",
+        " 3. Homogeneous Saving rates $\\implies$ preference for bequests $\\uparrow$, capital income is riskier & extremely bad fit in matching the upper tail of the wealth distribution\n",
+        "\n",
+        "![Counterfactual wealth distributions: baseline vs. shutting down each channel](fig1.png)\n",
+        "\n",
+        "Lastly, paper describes transitional dynamics of the wealth distribution within the confines of the model. In particular, paper conducted an analysis using the SCF 1962–1963 wealth distribution as a starting point, estimating model parameters to match with the 2007 SCF distribution and previously used transition matrices. The findings highlight a significant rise in wealth inequality during this period, with the top 1% share increasing from 24.2% to 33.6%. The updated estimates reveal that this surge in inequality can be traced through enhanced capital income risk and differential savings, resulting in a skewed wealth distribution that closely matches empirical data, especially at the higher end. However, this model overestimates social mobility across wealth brackets. \n",
+        "\n",
+        "![Transitional dynamics of the wealth distribution, 1962–2007](fig2.png)\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Conclusion\n",
+        "\n",
+        "The authors of the paper developed a standard macroeconomic model to explore the distribution of wealth in the United States, with a specific focus on the distribution's tail. The model is notable for its ability to closely fit the observed data across the entire wealth spectrum and accurately capturing the social mobility trends. Through their analysis, the authors successfully identified three key factors contributing to wealth accumulation: skewed and persistent earnings distribution, differential saving and bequest rates across wealth levels, and capital income risk associated with entrepreneurship. Each factor plays a distinct and empirically validated role in shaping both the wealth distribution and mobility. The paper also delves into the transitional dynamics of wealth distribution, with preliminary findings suggesting rapid changes over time, indicating promising areas for future research.\n",
+        "\n",
+        "For a discussion of how later work has built on these findings, see the companion [Subsequent Literature](Benhabib_et_al_2019_subsequent-literature.ipynb) notebook."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Limitations\n",
+        "\n",
+        "The model ignores the following  key features that are relevant for doing a proper quantitative study:\n",
+        "   - overlapping generation demographic structure which is crucial for modeling accidental bequests\n",
+        "   - permanent income heterogeneity and within lifetime permanent income risk (important for capturing savings done to counter that risk)\n",
+        "   - having luxury-type bequest motives. In their absence, even agents located at lower end of the wealth distribution saves for leaving bequests. But that is not supported in data. Luxury-type bequest motives can solve that problem.\n",
+        "   - mortality risk which again alters the saving behavior of retirees\n",
+        "   - medical risk\n",
+        "\n",
+        "Several of these limitations have been addressed by subsequent work; see the companion [Subsequent Literature](Benhabib_et_al_2019_subsequent-literature.ipynb) notebook for details on how {cite:t}`atkeson2022`, {cite:t}`bruggemann2025`, and others have extended this framework.\n",
+        ""
+      ]
+    }
+  ],
+  "metadata": {
+    "language_info": {
+      "name": "python"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This paper presents a comprehensive analysis of the factors influencing wealth dynamics and social mobility in the United States. Key findings include:\n",
-    "\n",
-    "The main findings are listed below:\n",
-    "\n",
-    "- Motivation: Wealth is unequally distributed, with significant skewness and a thick right tail, where the top 1% holds a disproportionately large share of wealth {cite:p}`saez2016,piketty2014`.\n",
-    "- The lifecycle model developed in the study identifies three main factors driving these outcomes: skewed earnings distribution, differential savings rates across wealth levels, and stochastic idiosyncratic returns to wealth. All three factors are crucial for matching the observed wealth distribution and mobility patterns.\n",
-    "- The model developed matches empirical data well, and counterfactuals provide insights into the relative importance of the above factors in driving the wealth accumulation and distribution in the US.\n",
-    "\n",
-    "For a detailed discussion of the foundational literature this paper builds on, see the companion **Prior Literature** notebook."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Non-Technical Methodical Overview\n",
-    "\n",
-    "The paper develops a macroeconomic model to explore wealth accumulation, distribution, and social mobility in the U.S., focusing on three main forces:\n",
-    "\n",
-    "1. Stochastic Earnings: A large literature in the context of Aiyagari-Bewley economies has shown that income variability plays a key role in wealth inequality, affecting saving decisions and consumption patterns, particularly for the bottom 60% of households {cite:p}`aiyagari1994,castaneda2003`. However, it does not account for the wealth concentration among the wealthiest.\n",
-    "\n",
-    "2. Heterogeneous Rate of Return: Studies have identified significant variations in the risk-adjusted returns on investments across households, contributing to the wealth distribution's long tail {cite:p}`fagereng2020,quadrini2000,cagetti2006`. This variation is consistent over time and linked with entrepreneurial activity. The theoretical foundations for this channel were laid by {cite:t}`benhabib2011`.\n",
-    "\n",
-    "3. Differential saving rates across wealth levels: The model includes increasing bequest motives with wealth, suggesting a stronger saving motive among the wealthiest, who aim to leave significant assets for their heirs {cite:p}`denardi2004`. This perpetuates the transfer of large estates through generations.\n",
-    "\n",
-    "The analysis finds that stochastic earnings, differential savings, and capital income risk critically shape the wealth distribution's tail and social mobility. Capital income risk and differential savings widen the wealth distribution's tail and influence mobility, particularly enhancing it at the top end but reducing upward mobility from the bottom 20%. Despite being less impactful in the tail, stochastic earnings are vital for overall wealth mobility. Additionally, their findings suggest a wealth-dependent return rate enhances model fit across the wealth distribution. The stochastic process for returns which best fits the data shares statistical properties with those uncovered by {cite:t}`fagereng2020` from Norwegian tax records.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### The Model\n",
-    "\n",
-    "A fairly simple microfounded model of lifecycle consumption and savings. Each agent's life span is finite and deterministic, T years. \n",
-    "\n",
-    "#### Features of the model\n",
-    "\n",
-    "1. Every period agents choose how much to consume ($c_t$) and save ($a_t$) out of their market resources.\n",
-    "2. All agents are subjected to a no borrowing constraint.\n",
-    "3. Agents leave bequests $a_{T}$ at the end of life T.\n",
-    "4. Wealth accumulates from savings and bequests.\n",
-    "5. Every agent is assigned an idiosyncratic rate of retturn r and life-time labor earnings profile $\\left\\{w_{t} \\right\\}_{t=1}^{T}$ possibly correlated with those of the parent. \n",
-    "6. Rate of return and earnings are stochastic across generations but deterministic within generation.\n",
-    "\n",
-    "#### Preferences\n",
-    "Preferences are composed of:\n",
-    "1. per period utility from consumption\n",
-    "2. warm-glow utility  from bequests at T, $e(a_{T})$\n",
-    "$$\n",
-    "\\begin{aligned}\n",
-    "& u(c_t) = \\frac{c_{t}^{1 - \\sigma}}{1 - \\sigma}, \\quad \\quad e(a_t) = A\\frac{a_{T}^{1 - \\mu}}{1 - \\mu} \\\\\n",
-    "\\end{aligned}\n",
-    "$$\n",
-    "\n",
-    "#### Recursive Formulation\n",
-    "Given initial wealth $a_0$, earnings profile and rate of return, each agent's optimization problem is:\n",
-    "$$\n",
-    "\\begin{aligned}\n",
-    "& V_{t}(a) = \\max_{c, a'} u(c) + \\beta V_{t+1}(a') \\\\\n",
-    "& \\text{s.t.c} \\\\\n",
-    "& a' = (1+r)a - c + w \\\\\n",
-    "& 0 \\leq c \\leq a, \\quad t = 1,..., T-1\\\\\n",
-    "& V_{T}(a) = u(c) + e(a')\\\\\n",
-    "\\end{aligned}\n",
-    "$$\n",
-    "\n",
-    "The solution to the above problem is a stochastic difference equation for the initial wealth of dynasties, induced by the $\\left\\{r^n, w^n \\right\\}_{n}$, mapping $a^{n-1}$ into $\\left\\{a^{n} \\right\\}_{n}$, where superscript correspond to the nth generation.\n",
-    "$$\n",
-    "\\begin{aligned}\n",
-    "& a^{n} = g(a^{n-1}; r^{n}, w^{n}) \\\\\n",
-    "\\end{aligned}\n",
-    "$$\n",
-    "\n",
-    "Under the given assumptions of the model, the following holds:\n",
-    "1. If $\\mu  = \\sigma$ $\\implies$ the stochastic process $\\left\\{a^{n} \\right\\}_{n}$ has a stationary distribution\n",
-    "2. If $\\mu  < \\sigma$ $\\implies$  savings rate increases with wealth (stationary dist. might not exist). If it does exist, then it displays a thick tail.\n",
-    "\n",
-    "#### Quantitative Analysis\n",
-    "\n",
-    "The paper uses method of simulated moments (MSM) to identify unknown parameters.\n",
-    "\n",
-    "1. Externally calibrate some parameters of the model\n",
-    "2. Estimate remaining parameters of the model by matching the targeted moments generated by the stationary distribution induced by the model and those in the data\n",
-    "\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Results\n",
-    "\n",
-    "At the estimated parameter values, the model induced wealth distribution closely resembles the wealth distribution in the data.\n",
-    "-  The estimates point to the existence of differential saving behavior (bequest motives)\n",
-    "- Capital income risk an important factor in driving wealth inequality\n",
-    "\n",
-    "Next, paper shuts down each of the three main factors listed above. The objective of this counterfactual exercise is to gauge the relative importance of the three mechanisms in driving the distribution of wealth.\n",
-    "\n",
-    "#### Summary\n",
-    "\n",
-    " 1. No rate of return heterogeneity $\\implies$ higher bequest motive (A doubles relative to baseline) & model can't match the upper tail of the wealth distribution (Table-15-row(3))\n",
-    "\n",
-    "\n",
-    " 2. No stochastic earnings $\\implies$ relative prefernce for bequests $\\uparrow$ while nothing else changes substantially & model does not miss as much in mimicing the upper tail of the wealth distribution $\\implies$ stochastic earnings not driving the behavior of the right-tail of wealth distribution. \n",
-    "    - However, social mobility matrix fit implied by this counterfactual is bad $\\implies$ stochastic earnings matter for social mobility\n",
-    "\n",
-    "\n",
-    " 3. Homogeneous Saving rates $\\implies$ preference for bequests $\\uparrow$, capital income is riskier & extremely bad fit in matching the upper tail of the wealth ditribution\n",
-    "\n",
-    "<img src=\"fig1.png\" alt=\"Alt text\" title=\"Optional title\" width=\"700\" height=\"700\"/>\n",
-    "\n",
-    "Lastly, paper describes transitional dynamics of the wealth distribution within the confines of the model. In particular, paper conducted an analysis using the SCF 1962–1963 wealth distribution as a starting point, estimating model parameters to match with the 2007 SCF distribution and previously used transition matrices. The findings highlight a significant rise in wealth inequality during this period, with the top 1% share increasing from 24.2% to 33.6%. The updated estimates reveal that this surge in inequality can be traced through enhanced capital income risk and differential savings, resulting in a skewed wealth distribution that closely matches empirical data, especially at the higher end. However, this model overestimates social mobility across wealth brackets. \n",
-    "\n",
-    "<img src=\"fig2.png\" alt=\"Alt text\" title=\"Optional title\" width=\"700\" height=\"700\"/>\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Conclusion\n",
-    "\n",
-    "The authors of the paper developed a standard macroeconomic model to explore the distribution of wealth in the United States, with a specific focus on the distribution's tail. The model is notable for its ability to closely fit the observed data across the entire wealth spectrum and accurately capturing the social mobility trends. Through their analysis, the authors successfully identified three key factors contributing to wealth accumulation: skewed and persistent earnings distribution, differential saving and bequest rates across wealth levels, and capital income risk associated with entrepreneurship. Each factor plays a distinct and empirically validated role in shaping both the wealth distribution and mobility. The paper also delves into the transitional dynamics of wealth distribution, with preliminary findings suggesting rapid changes over time, indicating promising areas for future research.\n",
-    "\n",
-    "For a discussion of how later work has built on these findings, see the companion **Subsequent Literature** notebook."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Limitations\n",
-    "\n",
-    "The model ignores the following  key features that are relevant for doing a proper quantitative study:\n",
-    "   - overlapping generation demographic structure which is crucial for modeling accidental bequests\n",
-    "   - permanent income heterogeneity and within lifetime permanent income risk (important for capturing savings done to counter that risk)\n",
-    "   - having luxury-type bequest motives. In their absence, even agents located at lower end of the wealth distribution saves for leaving bequests. But that is not supported in data. Luxury-type bequest motives can solve that problem.\n",
-    "   - mortality risk which again alters the saving behavior of retirees\n",
-    "   - medical risk\n",
-    "\n",
-    "Several of these limitations have been addressed by subsequent work; see the companion **Subsequent Literature** notebook for details on how {cite:t}`atkeson2022`, {cite:t}`bruggemann2025`, and others have extended this framework.\n"
-   ]
-  }
- ],
- "metadata": {
-  "language_info": {
-   "name": "python"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2
+  "nbformat": 4,
+  "nbformat_minor": 2
 }

--- a/models/We-Would-Like-In-Econ-ARK/Benhabib_et_al_2019/Benhabib_et_al_2019_intro.ipynb
+++ b/models/We-Would-Like-In-Econ-ARK/Benhabib_et_al_2019/Benhabib_et_al_2019_intro.ipynb
@@ -1,35 +1,35 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Wealth Distribution and Social Mobility in the US: A Quantitative Approach\n",
-    "\n",
-    "**Paper:** \"Wealth Distribution and Social Mobility in the US: A Quantitative Approach\" by Jess Benhabib, Alberto Bisin, and Mi Luo, *American Economic Review* 109(5): 1623–1647, 2019. DOI: [10.1257/aer.20151684](https://doi.org/10.1257/aer.20151684)"
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Wealth Distribution and Social Mobility in the US: A Quantitative Approach\n",
+        "\n",
+        "**Paper:** \"Wealth Distribution and Social Mobility in the US: A Quantitative Approach\" by Jess Benhabib, Alberto Bisin, and Mi Luo, *American Economic Review* 109(5): 1623–1647, 2019. DOI: [10.1257/aer.20151684](https://doi.org/10.1257/aer.20151684)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "**Original ballpark author:** Ashish Kumar — 2024-03-26\n",
+        "\n",
+        "**Updated by:** llorracc — 2026-01-27"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.12.0"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**Original ballpark author:** Ashish Kumar — 2024-03-26\n",
-    "\n",
-    "**Updated by:** AI Demo (Johns Hopkins University) — 2026-01-27"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "name": "python",
-   "version": "3.12.0"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "nbformat": 4,
+  "nbformat_minor": 4
 }

--- a/models/We-Would-Like-In-Econ-ARK/Benhabib_et_al_2019/myst.yml
+++ b/models/We-Would-Like-In-Econ-ARK/Benhabib_et_al_2019/myst.yml
@@ -3,6 +3,7 @@ version: 1
 project:
   title: "Wealth Distribution and Social Mobility in the US — Ballpark Entry"
   bibliography:
+    - self.bib
     - references.bib
     - subsequent-literature.bib
   toc:

--- a/models/We-Would-Like-In-Econ-ARK/Benhabib_et_al_2019/references.bib
+++ b/models/We-Would-Like-In-Econ-ARK/Benhabib_et_al_2019/references.bib
@@ -141,16 +141,6 @@
   year={2002}
 }
 
-@article{benhabib2019,
-  title={Wealth Distribution and Social Mobility in the {US}: A Quantitative Approach},
-  author={Benhabib, Jess and Bisin, Alberto and Luo, Mi},
-  journal={American Economic Review},
-  volume={109},
-  number={5},
-  pages={1623--1647},
-  year={2019},
-  doi={10.1257/aer.20151684}
-}
 
 @article{hubmer2021,
   title={The Historical Evolution of the Wealth Distribution: A Quantitative-Theoretic Investigation},

--- a/models/We-Would-Like-In-Econ-ARK/Benhabib_et_al_2019/self.bib
+++ b/models/We-Would-Like-In-Econ-ARK/Benhabib_et_al_2019/self.bib
@@ -1,0 +1,10 @@
+@article{benhabib2019,
+  title={Wealth Distribution and Social Mobility in the {US}: A Quantitative Approach},
+  author={Benhabib, Jess and Bisin, Alberto and Luo, Mi},
+  journal={American Economic Review},
+  volume={109},
+  number={5},
+  pages={1623--1647},
+  year={2019},
+  doi={10.1257/aer.20151684}
+}


### PR DESCRIPTION
Follow-up to PR #49 (merged before these fixes were pushed).

- Fix 6 typos inherited from original notebook (Weath, retturn, prefernce, mimicing, ditribution, Methodical)
- Fix heading hierarchy: single h1 title, h2 sections, h3 subsections
- Replace bold-text cross-references with clickable Markdown links to companion notebooks
- Replace raw HTML img tags with Markdown images with descriptive alt text
- Create self.bib for the subject paper entry; remove it from references.bib (category separation)
- Add self.bib to myst.yml bibliography list
- Move attribution to intro notebook only (SST); remove duplicated Updated-by from digest
- Change updater from AI Demo to llorracc

Made with [Cursor](https://cursor.com)