### PR TITLE
TaxingWomen: Bellman excerpt, DDSL stage decomposition, and dolo-plus YAML

### DIFF
--- a/models/We-Would-Like-In-Econ-ARK/TaxingWomen/GKV2012_Married_Period.yaml
+++ b/models/We-Would-Like-In-Econ-ARK/TaxingWomen/GKV2012_Married_Period.yaml
@@ -1,0 +1,303 @@
+# ============================================================
+# GKV (2012) "Taxing Women" — Married Household Period
+# Fully deterministic conditional on permanent types (z, x, q, b)
+# Two stages: ParticipationAndLabor (branching) → ConsSavings (EGM)
+#
+# Produced by Matsya (session: topics2026-TaxingWomen)
+# Source: Guner, Kaygusuz, and Ventura (2012), JME 59, 111-128
+# ============================================================
+
+name: GKV2012_Married_Period
+stages:
+  - ParticipationAndLabor
+  - ConsSavings_work
+  - ConsSavings_home
+
+# ============================================================
+# Stage 1: ParticipationAndLabor (branching)
+# ============================================================
+---
+name: ParticipationAndLabor
+kind: branching
+branch_control: agent
+
+symbols:
+  spaces:
+    Xa: '@def R+'
+    Xh: '@def R+'
+    Xw: '@def R+'
+    Xl: '@def [0,1]'
+
+  prestate:
+    a: '@in Xa'
+    h: '@in Xh'
+
+  states:
+    a_d: '@in Xa'
+    h_d: '@in Xh'
+
+  poststates:
+    work:
+      w_work: '@in Xw'
+      h_work: '@in Xh'
+    home:
+      w_home: '@in Xw'
+      h_home: '@in Xh'
+
+  controls:
+    d: '@in {work, home}'
+    l_m: '@in Xl'
+    l_f: '@in Xl'
+
+  values:
+    V[<]: '@in R'
+    V: '@in R'
+    V[>]:
+      work: V_work
+      home: V_home
+    V_work: '@in R'
+    V_home: '@in R'
+
+  values_marginal:
+    dV[<]: '@in R'
+    dV: '@in R'
+    dV[>]:
+      work: dV_work
+      home: dV_home
+    dV_work: '@in R'
+    dV_home: '@in R'
+
+  parameters:
+    beta: '@in R+'          # 0.972 per 5-year period
+    gamma: '@in R+'         # 0.4 (Frisch elasticity)
+    phi: '@in R+'           # 8.03 (labor disutility weight)
+    kappa: '@in R+'         # 0.132 (time cost of young children)
+    delta: '@in R+'         # 0.02 (human capital depreciation)
+    tau_k: '@in R+'         # 0.097 (capital income tax)
+    tau_p: '@in R+'         # 0.086 (payroll tax)
+    r: '@in R+'             # interest rate
+    w_wage: '@in R+'        # aggregate wage
+    q: '@in R+'             # participation cost (permanent)
+    z: '@in R+'             # husband's permanent type
+    x: '@in R+'             # wife's permanent type
+    b: '@in Z+'             # childbearing status
+    j: '@in Z+'             # current age
+    varpi_m: '@in R+'       # husband's age-efficiency varpi_m(z, j)
+    a_j_x: '@in R+'        # wife's HC growth parameter a_j^x
+    zeta_1: '@in R'         # tax function intercept
+    zeta_2: '@in R+'        # tax function slope
+    I_bar: '@in R+'         # mean income (tax normalization)
+    d_s: '@in R+'           # child care price d(s) for current child age
+    kappa_y: '@in {0,1}'    # young-children indicator
+
+equations:
+  arvl_to_dcsn_transition: |
+    # Identity — no shocks
+    a_d = a
+    h_d = h
+
+  dcsn_to_cntn_transition:
+    work: |
+      # Earnings and income
+      y_m = w_wage * varpi_m * l_m
+      y_f = w_wage * h_d * l_f
+      I = y_m + y_f + r * a_d
+
+      # Tax liabilities: T(I) = (zeta_1 + zeta_2 * log(I/I_bar)) * I
+      y_tilde = I / I_bar
+      tax = (zeta_1 + zeta_2 * log(y_tilde)) * I
+
+      # Child care cost (incurred when wife works)
+      cc = w_wage * d_s
+
+      # Total resources
+      w_work = a_d * (1 + r * (1 - tau_k)) + (y_m + y_f) * (1 - tau_p) - tax - cc
+
+      # Human capital: wife works → growth
+      h_work = h_d * exp(a_j_x)
+
+    home: |
+      # Earnings and income (wife does not work)
+      y_m = w_wage * varpi_m * l_m
+      I = y_m + r * a_d
+
+      # Tax liabilities
+      y_tilde = I / I_bar
+      tax = (zeta_1 + zeta_2 * log(y_tilde)) * I
+
+      # Total resources (no child care cost)
+      w_home = a_d * (1 + r * (1 - tau_k)) + y_m * (1 - tau_p) - tax
+
+      # Human capital: wife stays home → depreciation
+      h_home = h_d * exp(-delta)
+
+  cntn_to_dcsn_mover:
+    Bellman: |
+      # Labor disutility in each branch
+      disutil_work = phi * l_m^(1 + 1/gamma) / (1 + 1/gamma)
+                   + phi * (l_f + kappa_y * kappa)^(1 + 1/gamma) / (1 + 1/gamma)
+                   + q
+      disutil_home = phi * l_m^(1 + 1/gamma) / (1 + 1/gamma)
+                   + phi * (kappa_y * kappa)^(1 + 1/gamma) / (1 + 1/gamma)
+
+      # Discrete-continuous max: outer max over branches, inner max over hours
+      V = max_{d}{-disutil_work + V[>][work], -disutil_home + V[>][home]}
+
+  dcsn_to_arvl_mover:
+    Bellman: |
+      # No pre-decision shocks — identity
+      V[<] = V
+    ShadowBellman: |
+      # Marginal values pass through (no expectation)
+      dV[<] = dV
+
+
+# ============================================================
+# Stage 2: ConsSavings (work branch) — EGM-amenable
+# ============================================================
+---
+name: ConsSavings_work
+
+symbols:
+  spaces:
+    Xw: '@def R+'
+    Xh: '@def R+'
+    Xa: '@def R+'
+
+  prestate:
+    w_work: '@in Xw'
+    h_work: '@in Xh'
+
+  states:
+    m: '@in Xw'
+    h_next: '@in Xh'
+
+  poststates:
+    a_prime: '@in Xa'
+    h_out: '@in Xh'
+
+  controls:
+    c: '@in R+'
+
+  values:
+    V[<]: '@in R'
+    V: '@in R'
+    V[>]: '@in R'
+
+  values_marginal:
+    dV[<]: '@in R'
+    dV: '@in R'
+    dV[>]: '@in R'
+
+  parameters:
+    beta: '@in R+'
+
+equations:
+  arvl_to_dcsn_transition: |
+    m = w_work
+    h_next = h_work
+
+  dcsn_to_cntn_transition: |
+    a_prime = m - c
+    h_out = h_next
+
+  cntn_to_dcsn_mover:
+    Bellman: |
+      V = max_{c}{log(c) + beta * V[>]}
+    InvEuler: |
+      c[>] = (beta * dV[>])^(-1)
+    MarginalBellman: |
+      dV = 1 / c
+    cntn_to_dcsn_transition: |
+      m[>] = a_prime + c[>]
+
+  dcsn_to_arvl_mover:
+    Bellman: |
+      V[<] = V
+    ShadowBellman: |
+      dV[<] = dV
+
+
+# ============================================================
+# Stage 2: ConsSavings (home branch) — EGM-amenable
+# Structurally identical to work branch, different wiring
+# ============================================================
+---
+name: ConsSavings_home
+
+symbols:
+  spaces:
+    Xw: '@def R+'
+    Xh: '@def R+'
+    Xa: '@def R+'
+
+  prestate:
+    w_home: '@in Xw'
+    h_home: '@in Xh'
+
+  states:
+    m: '@in Xw'
+    h_next: '@in Xh'
+
+  poststates:
+    a_prime: '@in Xa'
+    h_out: '@in Xh'
+
+  controls:
+    c: '@in R+'
+
+  values:
+    V[<]: '@in R'
+    V: '@in R'
+    V[>]: '@in R'
+
+  values_marginal:
+    dV[<]: '@in R'
+    dV: '@in R'
+    dV[>]: '@in R'
+
+  parameters:
+    beta: '@in R+'
+
+equations:
+  arvl_to_dcsn_transition: |
+    m = w_home
+    h_next = h_home
+
+  dcsn_to_cntn_transition: |
+    a_prime = m - c
+    h_out = h_next
+
+  cntn_to_dcsn_mover:
+    Bellman: |
+      V = max_{c}{log(c) + beta * V[>]}
+    InvEuler: |
+      c[>] = (beta * dV[>])^(-1)
+    MarginalBellman: |
+      dV = 1 / c
+    cntn_to_dcsn_transition: |
+      m[>] = a_prime + c[>]
+
+  dcsn_to_arvl_mover:
+    Bellman: |
+      V[<] = V
+    ShadowBellman: |
+      dV[<] = dV
+
+
+# ============================================================
+# Period Wiring
+# ============================================================
+# Backward solve order: ConsSavings_{work,home} → ParticipationAndLabor
+#
+# Connectors (namespace matching):
+#   ParticipationAndLabor.poststates.work.{w_work, h_work}
+#     → ConsSavings_work.prestate.{w_work, h_work}
+#
+#   ParticipationAndLabor.poststates.home.{w_home, h_home}
+#     → ConsSavings_home.prestate.{w_home, h_home}
+#
+# Inter-period twist:
+#   ConsSavings_{work,home}.poststates.{a_prime, h_out}
+#     → next period ParticipationAndLabor.prestate.{a, h}
+#   via: a = a_prime, h = h_out

--- a/models/We-Would-Like-In-Econ-ARK/TaxingWomen/TaxingWomen-Bellman-enriched.md
+++ b/models/We-Would-Like-In-Econ-ARK/TaxingWomen/TaxingWomen-Bellman-enriched.md
@@ -1,0 +1,254 @@
+# Bellman Equations in Guner, Kaygusuz, and Ventura (2012)
+
+*Excerpted from: "Taxing Women: A Macroeconomic Analysis," Journal of Monetary Economics 59 (2012), 111–128, Sections 3–5.*
+
+## Timing and Demographics
+
+The model is a **stationary overlapping generations** economy. The model period is **5 years**. Agents are indexed by age $j \in \{1, 2, \ldots, J\}$, retire at age $J_R$, and die at age $J$. Population grows at rate $n$; the fraction of age-$j$ agents is $\mu_j$ with $\mu_{j+1} = \mu_j / (1+n)$.
+
+Individuals are born as either **single or married**; marital status **does not change** over time (marriage is absorbing, no divorce). Spouses are assumed to be the same age.
+
+**Important: there are no period-by-period stochastic shocks in this model.** All heterogeneity is determined at birth — types $z$, $x$, $q$, and $b$ are permanent. The model is a deterministic life-cycle problem conditional on initial types.
+
+## State Variables and Notation
+
+| Symbol | Meaning |
+|--------|---------|
+| $a$ | household assets ($a \geq 0$; $a' = 0$ at $j = J$) |
+| $z \in Z$ | male intrinsic type — **permanent**, drawn once at birth; $Z \subset \mathbb{R}_{++}$ is a finite set with 4 elements corresponding to education levels: high school, some college, college, more than college |
+| $x \in X$ | female intrinsic type — **permanent**, drawn once at birth; $X \subset \mathbb{R}_{++}$ is a finite set with 4 elements (same education categories) |
+| $h \in H$ | female human capital (endogenous); initial value $h_1 = \zeta(x)$ depends on type |
+| $q \in Q$ | utility cost of joint work — drawn **once** at start of marriage (not re-drawn); $Q \subset \mathbb{R}_{++}$ finite; distribution $\xi(q \mid z)$ is gamma, conditional on husband's type |
+| $b \in \{0,1,2\}$ | childbearing status — **permanent**, assigned at birth (0 = no children, 1 = early, 2 = late) |
+| $j \in \{1,\ldots,J\}$ | age; retirement at $J_R$ |
+| $k \in \{0,1\}$ | children present in household: $k=1$ iff $b \in \{1,2\}$ and $j \in \{b, b{+}1, b{+}2\}$; $k=0$ otherwise |
+| $k_y \in \{0,1\}$ | young (age-1) children present: $k_y = 1$ iff $b = j$ |
+
+**Marital matching.** The fraction of marriages between type-$x$ females and type-$z$ males is $M(x,z)$, exogenously given. The fraction of single type-$z$ males is $\omega(z)$ and single type-$x$ females is $\phi(x)$.
+
+## Children
+
+Children are assigned exogenously at birth. Early child bearers ($b=1$) have two children at ages $j = 1, 2, 3$. Late child bearers ($b=2$) have children at $j = 2, 3, 4$. Children last for 3 model periods (15 years). Children provide no utility but impose costs:
+
+- **Child care costs:** If a female with children works, the household pays $w \cdot d(s)$ where $s = j+1-b$ is the age of the children. Here $d(s)$ is units of child care labor per two children. The cost is incurred only when the female works: $w \cdot d(s) \cdot \chi(l)$ where $\chi(l) = \mathbf{1}\{l > 0\}$.
+- **Time cost:** Young children ($s = 1$, i.e., $b = j$) impose a fixed time cost $\kappa$ on the mother regardless of work status, entering utility as $\varphi(l + k_y \kappa)^{1+1/\gamma}$.
+
+## Prices, Technology, and Tax Parameters
+
+**Production.** An aggregate firm operates $F(K, L_g) = K^\alpha L_g^{1-\alpha}$. Factor prices are competitive: $w = F_2(K, L_g)$, $R = F_1(K, L_g)$, and $r = R - \delta_k$.
+
+| Symbol | Meaning |
+|--------|---------|
+| $w$ | competitive wage rate |
+| $r$ | net return on assets ($r = R - \delta_k$) |
+| $\tau_k$ | capital income tax rate |
+| $\tau_p$ | payroll tax rate (flat, on individual labor income) |
+| $T^S(I, k)$, $T^M(I, k)$ | income tax functions for singles and married households |
+
+**Tax function specification (Section 5).** The effective average tax rate is
+
+$$
+\tau(\tilde{y}) = \zeta_1 + \zeta_2 \log(\tilde{y}),
+$$
+
+where $\tilde{y}$ is household income expressed as a multiple of mean household income. Total tax liabilities are $T(I, k) = \tau(\tilde{y}) \cdot \tilde{y} \cdot \bar{I}$, where $\bar{I}$ is mean household income and $\tilde{y} = I / \bar{I}$. Separate $(\zeta_1, \zeta_2)$ estimates apply by marital status and presence of children:
+
+| Filing status | $\zeta_1$ | $\zeta_2$ |
+|---------------|-----------|-----------|
+| Married, no children | 0.1028 | 0.0582 |
+| Married, two children | 0.0789 | 0.0763 |
+| Single, no children | 0.1392 | 0.0481 |
+| Single, two children (head of household) | 0.090 | 0.0819 |
+
+The implied marginal tax rate is $\tau'(\tilde{y}) = \zeta_1 + \zeta_2(1 + \log(\tilde{y}))$, which is increasing in income (progressive).
+
+**Taxable income** $I$ is total labor plus capital income: $I = ra + w \cdot \text{(labor earnings)}$. Social security benefits are not taxed.
+
+**Social security.** Retired households receive type-dependent benefits $p_m^S(z)$, $p_f^S(x)$, or $p^M(x,z)$.
+
+## Male Productivity
+
+Each male's type $z$ is **permanent** (no stochastic transition). The age-$j$ productivity of a type-$z$ male is $\varpi_m(z, j)$, an exogenous deterministic age-efficiency profile. Males do not face human capital depreciation.
+
+## Female Human Capital Accumulation
+
+Each female starts with initial productivity $h_1 = \zeta(x)$ depending on her permanent type $x$. Thereafter, productivity evolves endogenously according to (Eq. 4 in the paper):
+
+$$
+h' = G(x, h, l, j) = \exp\!\bigl[\ln h + a_j^x\,\chi(l) - \delta\,(1 - \chi(l))\bigr],
+$$
+
+where:
+- $\chi(l) = \mathbf{1}\{l > 0\}$ is the participation indicator
+- $a_j^x$ is an age- and type-specific growth factor conditional on working (calibrated so that a female who works every period matches the male age-efficiency profile of the same type, up to a constant gender gap)
+- $\delta$ is the depreciation rate from non-participation
+
+This means: if the female works ($l > 0$), her human capital grows by $a_j^x$; if she does not work ($l = 0$), it depreciates by $\delta$. The decision is binary at the human-capital level — hours affect utility but not the growth/depreciation rate.
+
+## Preferences
+
+The momentary utility function for a **single female** is
+
+$$
+U_f^S(c, l, k_y) = \log(c) - \varphi\,(l + k_y \kappa)^{1+1/\gamma},
+$$
+
+and for a **single male**,
+
+$$
+U_m^S(c, l) = \log(c) - \varphi\, l^{1+1/\gamma}.
+$$
+
+For **married households**, the couple maximizes the sum of their members' utilities. When the female works, the household incurs a utility cost $q$. The married female's utility is
+
+$$
+U_f^M(c, l_f, q, k_y) = \log(c) - \varphi\,(l_f + k_y \kappa)^{1+1/\gamma} - \tfrac{1}{2}\,\chi_{\{l_f > 0\}}\, q,
+$$
+
+and the married male's utility is
+
+$$
+U_m^M(c, l_m, l_f, q) = \log(c) - \varphi\, l_m^{1+1/\gamma} - \tfrac{1}{2}\,\chi_{\{l_f > 0\}}\, q,
+$$
+
+where $\gamma > 0$ is the intertemporal (Frisch) elasticity of labor supply, $\varphi$ controls the disutility of work, $\kappa$ is the fixed time cost of young children for females, and consumption $c$ is a public good within the household. The parameters $\gamma$ and $\varphi$ are **independent of gender and marital status**.
+
+The household objective is **unitary**: the married household maximizes $U_f^M + U_m^M$ (no bargaining).
+
+## Calibrated Parameter Values (Table 3 of the paper)
+
+| Parameter | Symbol | Value |
+|-----------|--------|-------|
+| Population growth rate | $n$ | 1.1 (per 5-year period) |
+| Discount factor | $\beta$ | 0.972 (per 5-year period) |
+| Frisch elasticity of labor supply | $\gamma$ | 0.4 |
+| Disutility of market work | $\varphi$ | 8.03 |
+| Time cost of young children | $\kappa$ | 0.132 |
+| Child care cost, young children (age $s=1$) | $d(1)$ | 0.064 |
+| Child care cost, older children (age $s=2,3$) | $d(2)=d(3)$ | 0.049 |
+| Human capital depreciation (females) | $\delta$ | 0.02 |
+| Capital share | $\alpha$ | 0.343 |
+| Capital depreciation rate | $\delta_k$ | 0.055 |
+| Payroll tax rate | $\tau_p$ | 0.086 |
+| Capital income tax rate | $\tau_k$ | 0.097 |
+| Utility cost distribution | $\xi(q \mid z)$ | Gamma, calibrated to match LFP by education conditional on husband's type |
+
+---
+
+## Bellman Equation 1: Single Male
+
+The state for a single male is $(a, z, j)$. His problem is
+
+$$
+V_m^S(a, z, j) = \max_{a', l} \Bigl\{ U_m^S(c, l) + \beta\, V_m^S(a', z, j+1) \Bigr\}
+$$
+
+subject to the budget constraint
+
+$$
+c + a' =
+\begin{cases}
+a\bigl(1 + r(1-\tau_k)\bigr) + w\,\varpi_m(z,j)\,l\,(1-\tau_p) - T^S\bigl(w\,\varpi_m(z,j)\,l + ra,\; 0\bigr) & \text{if } j < J_R, \\[6pt]
+a\bigl(1 + r(1-\tau_k)\bigr) + p_m^S(z) - T^S(ra, 0) & \text{if } j \geq J_R,
+\end{cases}
+$$
+
+and $l \geq 0$, $a' \geq 0$ (with $a' = 0$ if $j = J$).
+
+Here $\varpi_m(z,j)$ is the age-$j$ productivity of a type-$z$ male, and $p_m^S(z)$ is his social security benefit.
+
+---
+
+## Bellman Equation 2: Single Female
+
+The state for a single female is $(a, h, x, b, j)$. Her problem is
+
+$$
+V_f^S(a, h, x, b, j) = \max_{a', l} \Bigl\{ U_f^S(c, l, k_y) + \beta\, V_f^S(a', h', x, b, j+1) \Bigr\}
+$$
+
+subject to the following budget constraints:
+
+**(i) With children** — if $b \in \{1,2\}$ and $j \in \{b,\, b{+}1,\, b{+}2\}$, then $k=1$ and
+
+$$
+c + a' = a\bigl(1+r(1-\tau_k)\bigr) + w\,h\,l\,(1-\tau_p) - T^S(w\,h\,l + ra,\; 1) - w\,d(j+1-b)\,\chi(l).
+$$
+
+Furthermore, if $b = j$ then $k_y = 1$.
+
+**(ii) Without children, not retired** — if $b = 0$, or $b \in \{1,2\}$ and $b+2 < j < J_R$, or $b = 2$ and $j = 1$, then $k = 0$ and
+
+$$
+c + a' = a\bigl(1+r(1-\tau_k)\bigr) + w\,h\,l\,(1-\tau_p) - T^S(w\,h\,l + ra,\; 0).
+$$
+
+**(iii) Retired** — if $j \geq J_R$, then $k = 0$ and
+
+$$
+c + a' = a\bigl(1+r(1-\tau_k)\bigr) + p_f^S(x) - T^S(ra,\; 0).
+$$
+
+In addition, $h' = G(x, h, l, j)$, and $l \geq 0$, $a' \geq 0$ (with $a' = 0$ if $j = J$).
+
+Here $d(s)$ is the per-child care cost when children are age $s$, and $\chi(l) = \mathbf{1}\{l > 0\}$.
+
+---
+
+## Bellman Equation 3: Married Household
+
+The state for a married couple is $(a, h, x, z, q, b, j)$. Their problem is
+
+$$
+V^M(a, h, x, z, q, b, j) = \max_{a', l_f, l_m} \Bigl\{ \bigl[U_f^M(c, l_f, q, k_y) + U_m^M(c, l_m, l_f, q)\bigr] + \beta\, V^M(a', h', x, z, q, b, j+1) \Bigr\}
+$$
+
+subject to the following budget constraints:
+
+**(i) With children** — if $b \in \{1,2\}$ and $j \in \{b,\, b{+}1,\, b{+}2\}$, then $k = 1$ and
+
+$$
+c + a' = a\bigl(1+r(1-\tau_k)\bigr) + w\bigl(\varpi_m(z,j)\,l_m + h\,l_f\bigr)(1-\tau_p) - T^M\bigl(w\,\varpi_m(z,j)\,l_m + w\,h\,l_f + ra,\; 1\bigr) - w\,d(j{+}1{-}b)\,\chi(l_f).
+$$
+
+Furthermore, if $b = j$ then $k_y = 1$.
+
+**(ii) Without children, not retired** — if $b = 0$, or $b \in \{1,2\}$ and $b+2 < j < J_R$, or $b = 2$ and $j = 1$, then $k = 0$ and
+
+$$
+c + a' = a\bigl(1+r(1-\tau_k)\bigr) + w\bigl(\varpi_m(z,j)\,l_m + h\,l_f\bigr)(1-\tau_p) - T^M\bigl(w\,\varpi_m(z,j)\,l_m + w\,h\,l_f + ra,\; 0\bigr).
+$$
+
+**(iii) Retired** — if $j \geq J_R$, then $k = 0$ and
+
+$$
+c + a' = a\bigl(1+r(1-\tau_k)\bigr) + p^M(x, z) - T^M(ra,\; 0).
+$$
+
+In addition,
+
+$$
+h' = G(x, h, l_f, j),
+$$
+
+and $l_m \geq 0$, $l_f \geq 0$, $a' \geq 0$ (with $a' = 0$ if $j = J$).
+
+---
+
+## Key Features of the Bellman Structure
+
+1. **No period-by-period shocks.** All heterogeneity is initial: types $z$, $x$, $q$, $b$ are drawn once at birth. Conditional on types, the life-cycle problem is fully deterministic. There is no shock-realization stage within a period.
+
+2. **Extensive margin for married females.** The utility cost $q$ of joint work, combined with childcare costs $w\,d(s)$ and human capital depreciation $\delta$, creates a non-trivial participation decision: for high enough $q$ it is optimal for only the husband to work.
+
+3. **Endogenous female human capital.** The law of motion $h' = G(x,h,l_f,j)$ means that non-participation today reduces future productivity, making the participation decision inherently dynamic. The human capital transition depends only on whether the female works ($\chi(l) = \mathbf{1}\{l>0\}$), not on hours conditional on participation.
+
+4. **Both intensive and extensive margins.** Hours $l_m$, $l_f$ are continuous controls (intensive margin). The wife's participation ($l_f > 0$ vs. $l_f = 0$) is the extensive margin, governed by comparing household utility under one-earner vs. two-earner configurations. Both husbands and wives choose hours endogenously.
+
+5. **Progressive taxation on households.** Under joint filing, the married female's effective marginal tax rate depends on her husband's income through the convex tax function $T^M(\cdot)$ with $\tau(\tilde{y}) = \zeta_1 + \zeta_2 \log(\tilde{y})$, creating a tax wedge against secondary-earner participation.
+
+6. **Gender-based tax experiments (Section 6).** The paper replaces the progressive functions $T^M, T^S$ with proportional rates $\tau_L$ (on married female labor earnings) and $\tau_H$ (on everyone else), nesting equal treatment ($\tau_L = \tau_H = \tau$) as a special case. Capital income is taxed at $\tau_k^* = \tau_k + \tau$. Two scenarios:
+   - **Narrow base:** singles pay $\tau$; married females pay $\tau_L < \tau$; married males pay $\tau_H > \tau$ to balance the budget.
+   - **Broad base:** married females pay $\tau_L$; everyone else (married males and all singles) pays $\tau_H$.
+
+   Revenue neutrality is maintained period-by-period by adjusting $\tau_H$.

--- a/models/We-Would-Like-In-Econ-ARK/TaxingWomen/TaxingWomen-Bellman-original.md
+++ b/models/We-Would-Like-In-Econ-ARK/TaxingWomen/TaxingWomen-Bellman-original.md
@@ -1,0 +1,177 @@
+# Bellman Equations in Guner, Kaygusuz, and Ventura (2012)
+
+*Excerpted from: "Taxing Women: A Macroeconomic Analysis," Journal of Monetary Economics 59 (2012), 111–128, Sections 3–4.*
+
+## State Variables and Notation
+
+| Symbol | Meaning |
+|--------|---------|
+| $a$ | household assets |
+| $z \in Z$ | male intrinsic type (permanent) |
+| $x \in X$ | female intrinsic type (permanent) |
+| $h \in H$ | female human capital (endogenous) |
+| $q \in Q$ | utility cost of joint work (drawn once at start of marriage) |
+| $b \in \{0,1,2\}$ | childbearing status (0 = none, 1 = early, 2 = late) |
+| $j \in \{1,\ldots,J\}$ | age; retirement at $J_R$ |
+| $k \in \{0,1\}$ | children present in household (determined by $b$ and $j$) |
+| $k_y \in \{0,1\}$ | young (age-1) children present |
+
+## Prices and Tax Parameters
+
+| Symbol | Meaning |
+|--------|---------|
+| $w$ | competitive wage rate |
+| $r$ | net return on assets ($r = R - \delta_k$) |
+| $\tau_k$ | capital income tax rate |
+| $\tau_p$ | payroll tax rate |
+| $T^S(I, k)$, $T^M(I, k)$ | income tax functions for singles and married households |
+
+## Preferences
+
+The momentary utility function for a **single female** is
+
+$$
+U_f^S(c, l, k_y) = \log(c) - \varphi\,(l + k_y \kappa)^{1+1/\gamma},
+$$
+
+and for a **single male**,
+
+$$
+U_m^S(c, l) = \log(c) - \varphi\, l^{1+1/\gamma}.
+$$
+
+For **married households**, the couple maximizes the sum of their members' utilities. When the female works, the household incurs a utility cost $q$. The married female's utility is
+
+$$
+U_f^M(c, l_f, q, k_y) = \log(c) - \varphi\,(l_f + k_y \kappa)^{1+1/\gamma} - \tfrac{1}{2}\,\chi_{\{l_f > 0\}}\, q,
+$$
+
+and the married male's utility is
+
+$$
+U_m^M(c, l_m, l_f, q) = \log(c) - \varphi\, l_m^{1+1/\gamma} - \tfrac{1}{2}\,\chi_{\{l_f > 0\}}\, q,
+$$
+
+where $\gamma > 0$ is the intertemporal elasticity of labor supply, $\varphi$ controls the disutility of work, $\kappa$ is the fixed time cost of young children for females, and consumption $c$ is a public good within the household.
+
+## Female Human Capital Accumulation
+
+Female productivity evolves endogenously according to
+
+$$
+h' = G(x, h, l, j) = \exp\!\bigl[\ln h + a_j^x\,\chi(l) - \delta\,(1 - \chi(l))\bigr],
+$$
+
+where $a_j^x$ is an age- and type-specific growth factor conditional on working, $\delta$ is the depreciation rate from non-participation, and $\chi(l) = \mathbf{1}\{l > 0\}$.
+
+---
+
+## Bellman Equation 1: Single Male
+
+The state for a single male is $(a, z, j)$. His problem is
+
+$$
+V_m^S(a, z, j) = \max_{a', l} \Bigl\{ U_m^S(c, l) + \beta\, V_m^S(a', z, j+1) \Bigr\}
+$$
+
+subject to the budget constraint
+
+$$
+c + a' =
+\begin{cases}
+a\bigl(1 + r(1-\tau_k)\bigr) + w\,\varpi_m(z,j)\,l\,(1-\tau_p) - T^S\bigl(w\,\varpi_m(z,j)\,l + ra,\; 0\bigr) & \text{if } j < J_R, \\[6pt]
+a\bigl(1 + r(1-\tau_k)\bigr) + p_m^S(z) - T^S(ra, 0) & \text{if } j \geq J_R,
+\end{cases}
+$$
+
+and $l \geq 0$, $a' \geq 0$ (with $a' = 0$ if $j = J$).
+
+Here $\varpi_m(z,j)$ is the age-$j$ productivity of a type-$z$ male, and $p_m^S(z)$ is his social security benefit.
+
+---
+
+## Bellman Equation 2: Single Female
+
+The state for a single female is $(a, h, x, b, j)$. Her problem is
+
+$$
+V_f^S(a, h, x, b, j) = \max_{a', l} \Bigl\{ U_f^S(c, l, k_y) + \beta\, V_f^S(a', h', x, b, j+1) \Bigr\}
+$$
+
+subject to the following budget constraints:
+
+**(i) With children** — if $b \in \{1,2\}$ and $j \in \{b,\, b{+}1,\, b{+}2\}$, then $k=1$ and
+
+$$
+c + a' = a\bigl(1+r(1-\tau_k)\bigr) + w\,h\,l\,(1-\tau_p) - T^S(w\,h\,l + ra,\; 1) - w\,d(j+1-b)\,\chi(l).
+$$
+
+Furthermore, if $b = j$ then $k_y = 1$.
+
+**(ii) Without children, not retired** — if $b = 0$, or $b \in \{1,2\}$ and $b+2 < j < J_R$, or $b = 2$ and $j = 1$, then $k = 0$ and
+
+$$
+c + a' = a\bigl(1+r(1-\tau_k)\bigr) + w\,h\,l\,(1-\tau_p) - T^S(w\,h\,l + ra,\; 0).
+$$
+
+**(iii) Retired** — if $j \geq J_R$, then $k = 0$ and
+
+$$
+c + a' = a\bigl(1+r(1-\tau_k)\bigr) + p_f^S(x) - T^S(ra,\; 0).
+$$
+
+In addition, $h' = G(x, h, l, j)$, and $l \geq 0$, $a' \geq 0$ (with $a' = 0$ if $j = J$).
+
+Here $d(s)$ is the per-child care cost when children are age $s$, and $\chi(l) = \mathbf{1}\{l > 0\}$.
+
+---
+
+## Bellman Equation 3: Married Household
+
+The state for a married couple is $(a, h, x, z, q, b, j)$. Their problem is
+
+$$
+V^M(a, h, x, z, q, b, j) = \max_{a', l_f, l_m} \Bigl\{ \bigl[U_f^M(c, l_f, q, k_y) + U_m^M(c, l_m, l_f, q)\bigr] + \beta\, V^M(a', h', x, z, q, b, j+1) \Bigr\}
+$$
+
+subject to the following budget constraints:
+
+**(i) With children** — if $b \in \{1,2\}$ and $j \in \{b,\, b{+}1,\, b{+}2\}$, then $k = 1$ and
+
+$$
+c + a' = a\bigl(1+r(1-\tau_k)\bigr) + w\bigl(\varpi_m(z,j)\,l_m + h\,l_f\bigr)(1-\tau_p) - T^M\bigl(w\,\varpi_m(z,j)\,l_m + w\,h\,l_f + ra,\; 1\bigr) - w\,d(j{+}1{-}b)\,\chi(l_f).
+$$
+
+Furthermore, if $b = j$ then $k_y = 1$.
+
+**(ii) Without children, not retired** — if $b = 0$, or $b \in \{1,2\}$ and $b+2 < j < J_R$, or $b = 2$ and $j = 1$, then $k = 0$ and
+
+$$
+c + a' = a\bigl(1+r(1-\tau_k)\bigr) + w\bigl(\varpi_m(z,j)\,l_m + h\,l_f\bigr)(1-\tau_p) - T^M\bigl(w\,\varpi_m(z,j)\,l_m + w\,h\,l_f + ra,\; 0\bigr).
+$$
+
+**(iii) Retired** — if $j \geq J_R$, then $k = 0$ and
+
+$$
+c + a' = a\bigl(1+r(1-\tau_k)\bigr) + p^M(x, z) - T^M(ra,\; 0).
+$$
+
+In addition,
+
+$$
+h' = G(x, h, l_f, j),
+$$
+
+and $l_m \geq 0$, $l_f \geq 0$, $a' \geq 0$ (with $a' = 0$ if $j = J$).
+
+---
+
+## Key Features of the Bellman Structure
+
+1. **Extensive margin for married females.** The utility cost $q$ of joint work, combined with childcare costs $w\,d(s)$ and human capital depreciation $\delta$, creates a non-trivial participation decision: for high enough $q$ it is optimal for only the husband to work.
+
+2. **Endogenous female human capital.** The law of motion $h' = G(x,h,l_f,j)$ means that non-participation today reduces future productivity, making the participation decision inherently dynamic.
+
+3. **Progressive taxation on households.** Under joint filing, the married female's effective marginal tax rate depends on her husband's income through the convex tax function $T^M(\cdot)$, creating a tax wedge against secondary-earner participation.
+
+4. **Gender-based tax experiments.** The paper replaces the progressive functions $T^M, T^S$ with proportional rates $\tau_H$ (on males/other) and $\tau_L$ (on married females), nesting equal treatment ($\tau_L = \tau_H$) as a special case, to evaluate the effects of differential taxation.

--- a/models/We-Would-Like-In-Econ-ARK/TaxingWomen/TaxingWomen-DDSL-stages.md
+++ b/models/We-Would-Like-In-Econ-ARK/TaxingWomen/TaxingWomen-DDSL-stages.md
@@ -1,0 +1,310 @@
+# GKV (2012) Married Household: DDSL Stage Decomposition
+
+*Produced via Matsya (session: `topics2026-TaxingWomen`), following the expository template from Carroll's SolvingMicroDSOPs lecture notes (Sections 4 and 9).*
+
+*Source: Guner, Kaygusuz, and Ventura, "Taxing Women: A Macroeconomic Analysis," JME 59 (2012), 111–128.*
+
+---
+
+## 1. Overview: The Period as a Stage List
+
+The married household's period is a **branching DAG**, not a linear list. The wife's participation decision creates a fan-out that reconverges at the end of the period.
+
+**Period short-name notation:**
+
+$$\text{Period}_j = [\ell\text{-branch}, \; c_w \mid c_h, \; \beta]$$
+
+Read: "labor-branch stage (with fan-out), then consumption-savings (one per branch, reconverging), then discounting."
+
+**DAG structure:**
+
+```
+                        ┌─── cons-work ───┐
+                        │                 │
+arrival ─── labor-branch┤                 ├─── disc ─── next period
+                        │                 │
+                        └─── cons-home ───┘
+```
+
+The `labor-branch` stage is a **branching stage** with `branch_control: agent` (the household chooses $d \in \{\text{work}, \text{home}\}$ to maximize). The two `cons` stages are structurally identical EGM-amenable consumption-savings problems that receive different resources and human capital from the branch.
+
+**Critical structural feature:** There are **no within-period stochastic shocks** in GKV (2012). All heterogeneity $(z, x, q, b)$ is permanent, drawn once at birth. Conditional on types, the life-cycle problem is fully deterministic.
+
+---
+
+## 2. Stage Inventory
+
+| Short-name | Control-name | Kind | Controls | Description |
+|---|---|---|---|---|
+| `labor-branch` | $\ell$ | Branching (agent) | $d, l_m, l_f$ | Wife participation + joint labor supply |
+| `cons-work` | $c_w$ | Sequential | $c$ | Consumption-savings, work branch |
+| `cons-home` | $c_h$ | Sequential | $c$ | Consumption-savings, home branch |
+| `disc` | $\beta$ | Sequential | — | Discounting (inter-period building) |
+
+---
+
+## 3. Rosetta Stone
+
+### State Variables
+
+| Math Symbol | Description | Type | Domain |
+|---|---|---|---|
+| $a$ | End-of-period assets | $k$-type (capital before returns) | $\mathbb{R}_+$ |
+| $h$ | Wife's human capital | $k$-type (capital before returns) | $\mathbb{R}_+$ |
+| $m$ | Cash-on-hand (total spendable resources) | $m$-type (after returns/taxes) | $\mathbb{R}_+$ |
+| $h'$ | Next-period human capital | $k$-type (determined by branch) | $\mathbb{R}_+$ |
+
+### Permanent Types (Parameters, Not State Variables)
+
+| Math Symbol | Description | Domain |
+|---|---|---|
+| $z$ | Husband's permanent productivity type | $\mathcal{Z} = \{1, 2, 3, 4\}$ (HS, some college, college, college+) |
+| $x$ | Wife's permanent productivity type | $\mathcal{X} = \{1, 2, 3, 4\}$ (same categories) |
+| $q$ | Utility cost of wife's participation | $\mathbb{R}_+$ (drawn once from $\text{Gamma}(\cdot \mid z)$) |
+| $b$ | Childbearing status | $\{0, 1, 2\}$ (none, early, late) |
+| $j$ | Age (period index) | $\{1, \ldots, J\}$ |
+
+### Controls
+
+| Math Symbol | Description | Domain | Stage |
+|---|---|---|---|
+| $d$ | Wife's participation indicator | $\{0, 1\}$ | `labor-branch` |
+| $l_m$ | Husband's labor supply | $[0, 1]$ | `labor-branch` |
+| $l_f$ | Wife's labor supply | $[0, 1]$ | `labor-branch` (work branch only) |
+| $c$ | Consumption | $\mathbb{R}_+$ | `cons-work`, `cons-home` |
+
+### Structural Functions
+
+| Math Symbol | Description | Depends on |
+|---|---|---|
+| $\varpi_m(z, j)$ | Husband's age-efficiency profile | Permanent type $z$, age $j$ |
+| $a_j^x$ | Wife's HC growth rate (if working) | Permanent type $x$, age $j$ |
+| $\delta$ | Wife's HC depreciation rate (if not working) | $= 0.02$ |
+| $T^M(I, k)$ | Married tax liability: $(\zeta_1 + \zeta_2 \ln(I/\bar{I})) \cdot I$ | Total income $I$, children $k$ |
+| $d(s)$ | Child care price | Child age $s = j + 1 - b$ |
+
+### Value Functions
+
+| Math Symbol | Perch | Description |
+|---|---|---|
+| $\mathrm{v}_{\prec}^{\ell}$ | Arrival at `labor-branch` | Value at period entry |
+| $\mathrm{v}_{\sim}^{\ell}$ | Decision at `labor-branch` | Value after (trivial) arrival-to-decision |
+| $\mathrm{v}_{\succ,w}^{\ell}$ | Continuation, work branch | Exit value toward `cons-work` |
+| $\mathrm{v}_{\succ,h}^{\ell}$ | Continuation, home branch | Exit value toward `cons-home` |
+| $\mathrm{v}_{\prec}^{c}$ | Arrival at `cons-*` | Value at entry to consumption stage |
+| $\mathrm{v}_{\sim}^{c}$ | Decision at `cons-*` | Value of consumption-savings problem |
+| $\mathrm{v}_{\succ}^{c}$ | Continuation at `cons-*` | End-of-period value |
+
+---
+
+## 4. Perch Tables
+
+### Stage 1: `labor-branch` [$\ell$] — Branching (agent)
+
+The household arrives with assets $a$ and wife's human capital $h$. No shocks resolve (all heterogeneity is permanent). The household jointly chooses participation $d$, husband's hours $l_m$, and (if $d = 1$) wife's hours $l_f$. The stage fans out into two branches with different resources and human capital transitions.
+
+| Perch | Indicator | State | Value function | Explanation |
+|---|---|---|---|---|
+| Arrival | $\prec$ | $(a, h)$ | $\mathrm{v}_{\prec}^{\ell} = \mathrm{v}_{\sim}^{\ell}$ | No shocks $\Rightarrow$ identity |
+| Decision | $\sim$ | $(a, h)$ | $\mathrm{v}_{\sim}^{\ell} = \max_{d} \left\{ \mathrm{v}^{\ell,w}, \; \mathrm{v}^{\ell,h} \right\}$ | Discrete max over branches |
+| Continuation (work) | $\succ_w$ | $(m_w, h'_w)$ | $\mathrm{v}_{\succ,w}^{\ell}$ | Resources + HC if wife works |
+| Continuation (home) | $\succ_h$ | $(m_h, h'_h)$ | $\mathrm{v}_{\succ,h}^{\ell}$ | Resources + HC if wife stays home |
+
+The branch-conditional decision values are:
+
+$$\mathrm{v}^{\ell,w}(a, h) \coloneqq \max_{l_m, l_f > 0} \left\{ -\varphi \frac{l_m^{1+1/\gamma}}{1+1/\gamma} - \varphi \frac{(l_f + k_y\kappa)^{1+1/\gamma}}{1+1/\gamma} - q + \mathrm{v}_{\succ,w}^{\ell}(m_w, h'_w) \right\}$$
+
+$$\mathrm{v}^{\ell,h}(a, h) \coloneqq \max_{l_m} \left\{ -\varphi \frac{l_m^{1+1/\gamma}}{1+1/\gamma} - \varphi \frac{(k_y\kappa)^{1+1/\gamma}}{1+1/\gamma} + \mathrm{v}_{\succ,h}^{\ell}(m_h, h'_h) \right\}$$
+
+**Transitions (decision → continuation):**
+
+*Work branch ($d = 1$):*
+
+$$y_m = w \cdot \varpi_m(z, j) \cdot l_m, \qquad y_f = w \cdot h \cdot l_f$$
+$$I_w = y_m + y_f + r \cdot a, \qquad \text{cc} = w \cdot d(s)$$
+$$m_w = a(1 + r(1 - \tau_k)) + (y_m + y_f)(1 - \tau_p) - T^M(I_w, k) - \text{cc}$$
+$$h'_w = h \cdot \exp(a_j^x)$$
+
+*Home branch ($d = 0$):*
+
+$$y_m = w \cdot \varpi_m(z, j) \cdot l_m, \qquad y_f = 0$$
+$$I_h = y_m + r \cdot a$$
+$$m_h = a(1 + r(1 - \tau_k)) + y_m(1 - \tau_p) - T^M(I_h, k)$$
+$$h'_h = h \cdot \exp(-\delta)$$
+
+**Arrival mover:** Identity — $\mathrm{v}_{\prec}^{\ell}(a, h) = \mathrm{v}_{\sim}^{\ell}(a, h)$ (no shocks).
+
+---
+
+### Stage 2w: `cons-work` [$c_w$] — Sequential (EGM)
+
+The household enters the work branch with resources $m_w$ and updated human capital $h'_w$. Standard consumption-savings with $\log$ utility. Human capital $h'_w$ is a pass-through state.
+
+| Perch | Indicator | State | Value function | Explanation |
+|---|---|---|---|---|
+| Arrival | $\prec$ | $(m, h')$ | $\mathrm{v}_{\prec}^{c_w} = \mathrm{v}_{\sim}^{c_w}$ | No shocks |
+| Decision | $\sim$ | $(m, h')$ | $\mathrm{v}_{\sim}^{c_w} = \max_{c} \left\{ \log(c) + \mathrm{v}_{\succ}^{c_w} \right\}$ | EGM-amenable |
+| Continuation | $\succ$ | $(a, h')$ | $\mathrm{v}_{\succ}^{c_w}$ | End-of-period assets + HC |
+
+**Transition (decision → continuation):** $a = m - c$, $h'$ passes through.
+
+**EGM (InvEuler):** $c_{[\succ]} = (\mathrm{v}_{\succ}^{c_w,\partial})^{-1}$ since $u^{\partial}(c) = 1/c$.
+
+**Reverse transition:** $m_{[\succ]} = a + c_{[\succ]}$
+
+**MarginalBellman:** $\mathrm{v}_{\sim}^{c_w,\partial} = 1/c$
+
+---
+
+### Stage 2h: `cons-home` [$c_h$] — Sequential (EGM)
+
+Structurally identical to `cons-work`. Different input $(m_h, h'_h)$, same code.
+
+| Perch | Indicator | State | Value function | Explanation |
+|---|---|---|---|---|
+| Arrival | $\prec$ | $(m, h')$ | $\mathrm{v}_{\prec}^{c_h} = \mathrm{v}_{\sim}^{c_h}$ | No shocks |
+| Decision | $\sim$ | $(m, h')$ | $\mathrm{v}_{\sim}^{c_h} = \max_{c} \left\{ \log(c) + \mathrm{v}_{\succ}^{c_h} \right\}$ | EGM-amenable |
+| Continuation | $\succ$ | $(a, h')$ | $\mathrm{v}_{\succ}^{c_h}$ | End-of-period assets + HC |
+
+---
+
+### Stage 3: `disc` [$\beta$] — Discounting
+
+| Perch | Indicator | State | Value function | Explanation |
+|---|---|---|---|---|
+| Arrival | $\prec$ | $\bullet$ | $\mathrm{v}_{\prec}^{\beta} = \mathrm{v}_{\sim}^{\beta}$ | No shocks |
+| Decision | $\sim$ | $\bullet$ | $\mathrm{v}_{\sim}^{\beta} = \beta \cdot \mathrm{v}_{\succ}^{\beta}$ | Apply $\beta$ |
+| Continuation | $\succ$ | $\bullet$ | $\mathrm{v}_{\succ}^{\beta}$ | Value at exit |
+
+n.b.: $\bullet$ is a generic passthrough state whose type ($k$-type) is inherited from the predecessor stage's continuation state $(a, h')$.
+
+---
+
+## 5. Connectors
+
+### Intra-Period Connectors
+
+| Connector | From | To | Mapping | Type check |
+|---|---|---|---|---|
+| $\mathcal{C}_1^w$ | `labor-branch` $\succ_w$ | `cons-work` $\prec$ | $(m_w, h'_w) \leftrightarrow (m, h')$ | $m$-type $\to$ $m$-type ✓ |
+| $\mathcal{C}_1^h$ | `labor-branch` $\succ_h$ | `cons-home` $\prec$ | $(m_h, h'_h) \leftrightarrow (m, h')$ | $m$-type $\to$ $m$-type ✓ |
+| $\mathcal{C}_2^w$ | `cons-work` $\succ$ | `disc` $\prec$ | $(a, h') \leftrightarrow (a, h')$ | $k$-type $\to$ $k$-type ✓ |
+| $\mathcal{C}_2^h$ | `cons-home` $\succ$ | `disc` $\prec$ | $(a, h') \leftrightarrow (a, h')$ | $k$-type $\to$ $k$-type ✓ |
+
+### Inter-Period Connector
+
+| Connector | From | To | Mapping | Type check |
+|---|---|---|---|---|
+| $\mathcal{C}_{\beta}$ | `disc` $\succ$ (period $j$) | `labor-branch` $\prec$ (period $j+1$) | $(a, h') \leftrightarrow (a, h)$ | $k$-type $\to$ $k$-type ✓ |
+
+**Type discipline:** The labor-branch stage converts $k$-type variables $(a, h)$ into $m$-type variables $(m_w, h'_w)$ or $(m_h, h'_h)$ through the budget constraint and human capital law of motion. The consumption stage converts $m$-type back to $k$-type through the savings decision. This is the standard $k \to m \to k$ cycle from SolvingMicroDSOPs Section 4.3.
+
+Note that $h$ and $h'$ are both $k$-type: human capital is a stock that earns returns (wages) when combined with labor, analogous to how financial capital $a$ earns returns $r$.
+
+---
+
+## 6. Flow Table
+
+| Element | Transition | Action |
+|---|---|---|
+| `labor-branch` | $(a, h) \to \{(m_w, h'_w), (m_h, h'_h)\}$ | Choose $d, l_m, l_f$; compute taxes, child care, HC update; **fan-out** |
+| $\mathcal{C}_1^w(m_w, h'_w \leftrightarrow m, h')$ | $m_w \to m$ | Rename (work branch) |
+| $\mathcal{C}_1^h(m_h, h'_h \leftrightarrow m, h')$ | $m_h \to m$ | Rename (home branch) |
+| `cons-work` | $m \to a$ | Choose $c$; EGM (work branch) |
+| `cons-home` | $m \to a$ | Choose $c$; EGM (home branch) |
+| $\mathcal{C}_2^{w,h}(a, h' \leftrightarrow a, h')$ | identity | **Fan-in** (reconverge) |
+| `disc` | — | Apply $\beta$ |
+| $\mathcal{C}_{\beta}(a, h' \leftrightarrow a, h)$ | $h' \to h$ | Inter-period rename |
+
+**Period as stage list (DAG notation):**
+
+$$\text{Period}_j = \left[\ell, \; \begin{pmatrix} c_w \\ c_h \end{pmatrix}, \; \beta \right]$$
+
+---
+
+## 7. DAG Diagram with Perch Detail
+
+```
+Period j
+═══════════════════════════════════════════════════════════════════
+
+  labor-branch [ℓ]
+  ┌─────────────────────────────────────────────────────────┐
+  │  ≺:(a,h) ──identity──▶ ∼:(a,h) ──┬── ▹_w:(m_w, h'_w) │
+  │                         max{d}    │                     │
+  │                                   └── ▹_h:(m_h, h'_h)  │
+  └───────────────────────────────┬──────────────┬──────────┘
+                                  │              │
+                          C_1^w(m_w↔m)    C_1^h(m_h↔m)
+                                  │              │
+                                  ▼              ▼
+                          cons-work [c_w]  cons-home [c_h]
+                          ┌────────────┐  ┌────────────┐
+                          │ ≺:(m,h')   │  │ ≺:(m,h')   │
+                          │ ∼: max_c   │  │ ∼: max_c   │
+                          │ ▹:(a,h')   │  │ ▹:(a,h')   │
+                          └─────┬──────┘  └──────┬─────┘
+                                │                │
+                          C_2^w(a↔a)       C_2^h(a↔a)
+                                │                │
+                                └───────┬────────┘
+                                        │  fan-in
+                                        ▼
+                                   disc [β]
+                                ┌──────────┐
+                                │ v_▹ = β  │
+                                │ v_≺(j+1) │
+                                └────┬─────┘
+                                     │
+                               C_β(a↔a, h'↔h)
+                                     │
+                                     ▼
+                              Period j+1 arrival
+```
+
+---
+
+## 8. Backward Solution Order
+
+Solve from continuation toward arrival:
+
+1. **Solve `disc`:** Given $\mathrm{v}_{\prec}^{\ell}(\cdot; j+1)$ from next period, compute $\mathrm{v}_{\succ}^{c}(a, h') = \beta \, \mathrm{v}_{\prec}^{\ell}(a, h'; j+1)$
+
+2. **Solve `cons-work`:** Given $\mathrm{v}_{\succ}^{c_w}$, use EGM to compute $\mathrm{v}_{\sim}^{c_w}(m, h')$ and policy $c^*(m, h')$. Propagate $\mathrm{v}_{\prec}^{c_w} = \mathrm{v}_{\sim}^{c_w}$ (no shocks).
+
+3. **Solve `cons-home`:** Identical EGM procedure, yielding $\mathrm{v}_{\sim}^{c_h}(m, h')$.
+
+4. **Solve `labor-branch`:** For each $(a, h)$ on the state grid:
+
+   a. **Work branch:** Receive $\mathrm{v}_{\succ,w}^{\ell} = \mathrm{v}_{\prec}^{c_w}$ via $\mathcal{C}_1^w$. Optimize over $(l_m, l_f)$ using the labor FOCs and the marginal value $\partial_m \mathrm{v}_{\prec}^{c_w}$. Compute $\mathrm{v}^{\ell,w}(a, h)$.
+
+   b. **Home branch:** Receive $\mathrm{v}_{\succ,h}^{\ell} = \mathrm{v}_{\prec}^{c_h}$ via $\mathcal{C}_1^h$. Optimize over $l_m$ only. Compute $\mathrm{v}^{\ell,h}(a, h)$.
+
+   c. **Discrete choice:** $\mathrm{v}_{\sim}^{\ell}(a, h) = \max\{\mathrm{v}^{\ell,w}(a, h), \; \mathrm{v}^{\ell,h}(a, h)\}$
+
+   d. **Arrival:** $\mathrm{v}_{\prec}^{\ell}(a, h; j) = \mathrm{v}_{\sim}^{\ell}(a, h)$ (no shocks).
+
+---
+
+## 9. Modularity Properties
+
+The three principles from SolvingMicroDSOPs Section 4.1 are satisfied:
+
+**Principle 1 — Self-contained stages.** Each stage's internal logic (perch transitions, optimization, EGM) is defined independently. The `cons-work` and `cons-home` stages are literally the same code with different input data.
+
+**Principle 2 — Rearrangement by rewiring.** To study a model variant where the participation decision happens *after* savings (choose $a'$ first, then decide whether wife works), only the stage order and connectors change: $[c, \; \ell\text{-branch}, \; \beta]$. No stage code is rewritten.
+
+**Principle 3 — Namespace uniqueness.** Within the period, $a$ always means end-of-period assets ($k$-type), $m$ always means cash-on-hand ($m$-type), $h$ is beginning-of-period human capital, $h'$ is next-period human capital. The connectors handle all renaming explicitly.
+
+---
+
+## 10. Tax Policy Counterfactuals in the DAG
+
+The modularity pays off for GKV's policy experiments. Switching tax regimes affects **only the `labor-branch` stage's transition equations** — the consumption stages, connectors, discounting, and DAG structure are all unchanged:
+
+| Policy experiment | What changes | What stays |
+|---|---|---|
+| Joint $\to$ individual filing | $T^M(I, k) \to T^S(y_m, 0) + T^S(y_f, k)$ in `labor-branch` | `cons-*`, `disc`, all connectors |
+| Flat tax ($\tau_L$ on wives, $\tau_H$ on husbands) | $T^M \to \tau_L y_f + \tau_H y_m$ in `labor-branch` | Everything else |
+| Child care subsidy | $\text{cc} = w \cdot d(s) \to (1-\sigma) w \cdot d(s)$ in `labor-branch` | Everything else |
+| Remove participation cost | $q = 0$ in `labor-branch` Bellman | Everything else |

--- a/models/We-Would-Like-In-Econ-ARK/TaxingWomen/verification.md
+++ b/models/We-Would-Like-In-Econ-ARK/TaxingWomen/verification.md
@@ -1,9 +1,9 @@
 # Verification (short)
 
-**Accepted:** Perch structure, EGM recipe, envelope condition, Markov forward mover, prices-as-parameters treatment — all match the paper.
+**Accepted:** Two-stage branching decomposition (labor-branch → cons-savings), DAG wiring with separate work/home continuation legs, EGM-amenable structure exploiting additive separability — all faithful to GKV's discrete-continuous setup.
 
-**Edited:** Added explicit (1+g) growth factor note in the transition and the β̃ < 1 restriction, both absent from the original notebook summary.
+**Edited:** Corrected preferences from Cobb-Douglas to additively separable log-linear (the paper's actual functional form); enriched the Bellman markdown with the log-linear tax function (Table 2 coefficients), calibrated parameters (Table 3), binary human capital law of motion χ(l) = 1{l > 0}, and children time/goods cost schedules — all absent from the initial excerpt and needed by Matsya to produce a correct YAML.
 
-**Rejected:** Nothing outright. Model B as "same stage, expanded controls" is faithful to the paper.
+**Rejected:** Matsya's initial ShockRealization stage — GKV types (z, q) are permanent, not period-by-period Markov draws, so a within-period shock stage is fictitious.
 
 **Matsya session:** `topics2026-TaxingWomen`

--- a/models/We-Would-Like-In-Econ-ARK/TaxingWomen/verification.md
+++ b/models/We-Would-Like-In-Econ-ARK/TaxingWomen/verification.md
@@ -1,5 +1,9 @@
-# Verification: What I Accepted, Edited, or Rejected from Matsya
+# Verification (short)
 
-Kept the two-stage branching split — it's correct. Killed the fake shock stage (GKV types are permanent, no within-period draws). Matsya also got the preferences wrong at first; I corrected it, it fixed itself. Rest was fine, left it alone.
+**Accepted:** Perch structure, EGM recipe, envelope condition, Markov forward mover, prices-as-parameters treatment — all match the paper.
+
+**Edited:** Added explicit (1+g) growth factor note in the transition and the β̃ < 1 restriction, both absent from the original notebook summary.
+
+**Rejected:** Nothing outright. Model B as "same stage, expanded controls" is faithful to the paper.
 
 **Matsya session:** `topics2026-TaxingWomen`

--- a/models/We-Would-Like-In-Econ-ARK/TaxingWomen/verification.md
+++ b/models/We-Would-Like-In-Econ-ARK/TaxingWomen/verification.md
@@ -1,0 +1,5 @@
+# Verification: What I Accepted, Edited, or Rejected from Matsya
+
+Kept the two-stage branching split — it's correct. Killed the fake shock stage (GKV types are permanent, no within-period draws). Matsya also got the preferences wrong at first; I corrected it, it fixed itself. Rest was fine, left it alone.
+
+**Matsya session:** `topics2026-TaxingWomen`


### PR DESCRIPTION
## Summary

- Excerpt the Bellman equations from Guner, Kaygusuz & Ventura (2012) "Taxing Women" (JME 59, 111–128)
- Decompose the married household problem into DDSL stages (branching DAG with perch tables, connectors, flow tables) following the SolvingMicroDSOPs expository template
- Draft a dolo-plus YAML for the married household period

**Matsya session:** `topics2026-TaxingWomen`

## Committed artifacts

| File | Description |
|------|-------------|
| `TaxingWomen-Bellman-original.md` | Initial Bellman excerpt from the paper (before Matsya feedback) |
| `TaxingWomen-Bellman-enriched.md` | Enriched version with tax function specification, calibrated parameters, type structure, human capital details (added after Matsya identified gaps) |
| `TaxingWomen-DDSL-stages.md` | Final stage decomposition in SolvingMicroDSOPs style: perch tables, Rosetta Stone, flow table, DAG diagram, connectors with type checking |
| `GKV2012_Married_Period.yaml` | Dolo-plus YAML for the married household branching period |
| `verification.md` | What was accepted/edited/rejected from Matsya |

All files under `models/We-Would-Like-In-Econ-ARK/TaxingWomen/`.

## Verification

**Accepted:** Two-stage branching decomposition (labor-branch → cons-savings), DAG wiring with separate work/home continuation legs, EGM-amenable structure exploiting additive separability — all faithful to GKV's discrete-continuous setup.

**Edited:** Corrected preferences from Cobb-Douglas to additively separable log-linear (the paper's actual functional form); enriched the Bellman markdown with the log-linear tax function (Table 2 coefficients), calibrated parameters (Table 3), binary human capital law of motion χ(l) = 1{l > 0}, and children time/goods cost schedules — all absent from the initial excerpt and needed by Matsya to produce a correct YAML.

**Rejected:** Matsya's initial ShockRealization stage — GKV types (z, q) are permanent, not period-by-period Markov draws, so a within-period shock stage is fictitious.