### PR TITLE
Formalize and finalize GKN (2012): revisions from Claude Opus 4.6 review

### DIFF
--- a/models/We-Would-Like-In-Econ-ARK/GKNMonetaryPolicyHA/AGENTS.md
+++ b/models/We-Would-Like-In-Econ-ARK/GKNMonetaryPolicyHA/AGENTS.md
@@ -1,0 +1,47 @@
+# Ballpark entry: Gornemann, Kuester, and Nakajima (2012)
+
+> Structured brief for coding agents (Claude Code, Cursor, etc.). Human-facing content lives in [`GKNMonetaryPolicyHA.ipynb`](GKNMonetaryPolicyHA.ipynb).
+
+## Paper
+
+- **Citation:** Gornemann, Nils, Keith Kuester, and Makoto Nakajima (2012), "Monetary Policy with Heterogeneous Agents," Philadelphia Fed Working Paper 12-21.
+- **DOI:** [10.21799/frbp.wp.2012.21](https://doi.org/10.21799/frbp.wp.2012.21)
+- **Core model:** New Keynesian DSGE with heterogeneous households (employment status × skill × mutual-fund shares), search-and-matching labor market frictions, incomplete asset markets, and nominal rigidities. Households choose consumption and mutual-fund shares; aggregate state includes capital, employment, TFP, monetary-policy shock, and the cross-sectional distribution. Closed by a Krusell-Smith forecasting rule.
+- **Why in-ballpark:** The paper is among the first to rigorously analyze the distributional consequences of monetary policy in a heterogeneous-agent New Keynesian framework with frictional labor markets — a natural candidate for HARK's Markov-chain exogenous-state and search-and-matching machinery.
+
+## If a user asks to work on this item
+
+1. **Read first:** `docs/gkn-bellman-improved.md` — SMD-polished stage decomposition with perch table, EGM channel, and all employment transitions. This is the authoritative formalized statement.
+2. **Then read:** `docs/gkn-bellman-excerpt.md` — comprehensive symbol table, Bellman equations faithful to the paper, perch decomposition, and full calibration. This is the Matsya input document.
+3. **Paper source for AI ingestion:** `Gornemann_2012.pdf`. No `.mmd` (Pandoc-converted) version is available yet.
+
+## Formalization status
+
+- Explicit recursive formulation: present in `GKNMonetaryPolicyHA.ipynb` → "The Model" section (legacy slideware format).
+- `bellman-excerpt.md`: committed (`docs/gkn-bellman-excerpt.md`) — includes comprehensive symbol table and perch decomposition.
+- `bellman-excerpt-SMD-polished.md`: committed as `docs/gkn-bellman-improved.md`.
+- `dolo-plus-draft.yaml`: committed (`docs/gkn-dolo.yaml`).
+- `verification.md`: committed (`docs/gkn-verification.md`).
+- `matsya-session.txt`: committed (`docs/matsya-session.txt`); session name: `topics2026-mon-policy`.
+
+## Known model features requiring attention in a formalization pass
+
+- **Pre-transition vs. post-transition aggregate state.** The paper distinguishes \(\tilde{X}\) (pre-transition, before separations/matching) from \(X\) (post-transition). The employment transition probability \(f\) is evaluated at \(\tilde{X}'\), not \(X'\). The YAML now includes `X_tilde_prime = G_tilde(X)` but dolo-plus has no canonical idiom for this distinction. See `# workaround:` comment in `gkn-dolo.yaml`.
+- **Krusell-Smith aggregate law of motion.** `H(X, Z', D')` is a black-box forecasting rule — the paper does not give a closed form (Appendix B). The YAML uses `H` as a placeholder. See `# unresolved:` comment in `gkn-dolo.yaml`.
+- **State-contingent employment transitions.** Employment transition probabilities depend on the aggregate state through the job-finding rate \(f(\tilde{X}')\), which itself depends on endogenous vacancies satisfying a free-entry condition. This is not a simple Markov chain — it is state-dependent.
+- **Skill transition matrix retrieval.** Matsya could not retrieve the skill transition matrix from piped input; the \(4 \times 4\) matrix was filled in by hand from Table 2. Verified against the paper.
+- **Grid settings are placeholders.** `n_a = 200`, `a_max = 500.0`, `n_X = 3` are reasonable defaults but not from the paper.
+
+## Common next tasks (grounded)
+
+1. **Produce `.mmd` from PDF.** Run `pandoc Gornemann_2012.pdf -o Gornemann_2012.mmd` to create an AI-ingestible version of the paper. Currently only the PDF is committed.
+2. **Refactor legacy notebook into four-notebook exposition layer.** The current `GKNMonetaryPolicyHA.ipynb` is a monolithic slideware notebook. CONTRIBUTING.md requires `_intro.ipynb`, `_prior-literature.ipynb`, `_summary.ipynb`, `_subsequent-literature.ipynb`, plus `index.md`. See the Benhabib entry for reference structure.
+3. **Add `references.bib` and `self.bib`.** No bib files exist yet. At minimum, the paper's own entry (`self.bib`) and the prior-literature references (Mortensen-Pissarides, Rotemberg, Krusell-Smith, Nakajima 2012, etc.) need bib entries.
+4. **Resolve the KS forecasting-rule placeholder in the YAML.** If Appendix B provides enough detail, the `H` function could be specified as a log-linear rule with estimated coefficients.
+5. **Add `index.md` with required frontmatter.** Needs `tier:`, `econ_ark_topic:`, `jel:`, `difficulty:`, `has_formalization_layer:`, etc.
+
+## Workflow reminders
+
+- **Matsya session:** use `--session topics2026-mon-policy` for all matsya calls on this item.
+- **Paper verification:** Matsya output must be checked against the paper PDF, not only against the ballpark notebook. See `docs/gkn-verification.md` for the accept/edit/reject record.
+- **When flagging workarounds in YAML:** use inline `# workaround:` or `# unresolved:` comments rather than silently fudging non-canonical syntax.

--- a/models/We-Would-Like-In-Econ-ARK/GKNMonetaryPolicyHA/docs/gkn-bellman-excerpt.md
+++ b/models/We-Would-Like-In-Econ-ARK/GKNMonetaryPolicyHA/docs/gkn-bellman-excerpt.md
@@ -1,0 +1,180 @@
+# Household Bellman Problem — Excerpt from Gornemann, Kuester, Nakajima (2012)
+
+Faithful summary of the household dynamic program in Section 2 of the paper.
+
+## States
+
+**Aggregate state** (post labor-market transitions):
+
+\[
+X = (K,\; N,\; Z,\; D,\; \mu),
+\]
+
+where \(K\) is capital, \(N\) is employment, \(Z\) is TFP, \(D\) is the monetary-policy shock, and \(\mu\) is the cross-sectional distribution of households.
+
+**Individual state:** \((e,\, s,\, a)\) — employment status \(e \in \{0,1\}\), skill level \(s \in S\), and mutual-fund shares \(a \in A \subseteq \mathbb{R}\).
+
+The paper also defines a **pre-transition** aggregate state \(\tilde{X} = (K, \tilde{N}, Z, D, \tilde{\mu})\), measured at the start of the period before separations and matching occur.
+
+## Timing
+
+1. Households enter the period with state \((\tilde{e}, s, a)\) and observe \(\tilde{X}\).
+2. Employed households are separated with probability \(\lambda\).
+3. All jobless households (including newly separated) search; matches form with probability \(f(\tilde{X})\). The aggregate state updates to \(X = \hat{G}(\tilde{X})\).
+4. Households choose consumption \(c\) and next-period shares \(a'\). Production occurs.
+5. New shocks \((Z', D', s')\) are drawn; the economy enters next period at \(\tilde{X}'\).
+
+## Employment Transitions
+
+For a household that is **employed** at the consumption stage, next-period employment probabilities are:
+
+- Stays employed: \(1 - \lambda + \lambda\, f(\tilde{X}')\) — keeps job, or separates but re-matches immediately.
+- Becomes unemployed: \(\lambda\bigl(1 - f(\tilde{X}')\bigr)\) — separates and fails to match.
+
+For an **unemployed** household:
+
+- Becomes employed: \(f(\tilde{X}')\).
+- Stays unemployed: \(1 - f(\tilde{X}')\).
+
+## Employed Household Bellman (eq. 1)
+
+\[
+W(X, 1, s, a) =
+\max_{c,\; a' \geq 0}
+\left\{
+u(c) + \beta\,\mathbb{E}\!\left[
+  \bigl(1 - \lambda + \lambda\, f(\tilde{X}')\bigr)\, W(X', 1, s', a')
+  + \lambda\bigl(1 - f(\tilde{X}')\bigr)\, W(X', 0, s', a')
+\right]
+\right\}
+\]
+
+subject to the budget constraint
+
+\[
+c + p_a(X)\,a' = \bigl(p_a(X) + d_a(X)\bigr)\,a \;+\; w(X)\,s\,\bigl(1 - \tau(X)\bigr).
+\]
+
+## Unemployed Household Bellman (eq. 3)
+
+\[
+W(X, 0, s, a) =
+\max_{c,\; a' \geq 0}
+\left\{
+u(c) + \beta\,\mathbb{E}\!\left[
+  f(\tilde{X}')\, W(X', 1, s', a')
+  + \bigl(1 - f(\tilde{X}')\bigr)\, W(X', 0, s', a')
+\right]
+\right\}
+\]
+
+subject to
+
+\[
+c + p_a(X)\,a' = \bigl(p_a(X) + d_a(X)\bigr)\,a \;+\; b\,s.
+\]
+
+## Preferences
+
+Period utility is CRRA:
+
+\[
+u(c) = \frac{c^{1-\sigma}}{1-\sigma}, \qquad \sigma = 1.5.
+\]
+
+Labor supply is inelastic: a household works full-time (\(e=1\)) or not at all (\(e=0\)). The time-discount factor is \(\beta = 0.966\).
+
+## Skill Process
+
+There are four discrete skill levels, \(s \in S = \{s_1, s_2, s_3, s_4\}\):
+
+| Level | Value | Interpretation |
+|---|---|---|
+| \(s_1\) | 0.123 | Low |
+| \(s_2\) | 0.421 | Medium |
+| \(s_3\) | 1.435 | High |
+| \(s_4\) | 34.65 | Super-skilled |
+
+Skills evolve according to a Markov chain with transition matrix \(\pi_{s,s'}\) (Table 2 of the paper):
+
+\[
+\pi = \begin{pmatrix}
+0.9719 & 0.0275 & 0.0000 & 0.0006 \\
+0.0275 & 0.9444 & 0.0275 & 0.0006 \\
+0.0000 & 0.0275 & 0.9719 & 0.0006 \\
+0.0183 & 0.0183 & 0.0183 & 0.9450
+\end{pmatrix}.
+\]
+
+The lower three levels are obtained by discretizing an AR(1) for log productivity (Tauchen method). The super-skilled state is calibrated to match U.S. wealth concentration. Skill transitions are drawn at the end of each period; they do not depend on employment status or aggregate state.
+
+## Wage Function
+
+The wage per efficiency unit is a reduced-form function of aggregate output (eq. 39):
+
+\[
+\log w(X) - \log \bar{w} = \varepsilon_w \bigl(\log y(X) - \log \bar{y}\bigr), \qquad \varepsilon_w = 0.45,
+\]
+
+where \(\bar{w}\) and \(\bar{y}\) are steady-state values. Values of \(\varepsilon_w < 1\) capture wage stickiness.
+
+## Budget Constraint Notation
+
+| Symbol | Meaning |
+|---|---|
+| \(p_a(X)\) | Ex-dividend mutual-fund share price |
+| \(d_a(X)\) | Dividends per share |
+| \(w(X)\) | Wage per efficiency unit |
+| \(\tau(X)\) | Proportional payroll tax |
+| \(b\) | Unemployment benefit per efficiency unit |
+
+The short-sale constraint \(a' \geq 0\) rules out borrowing. The expectation \(\mathbb{E}\) is over \((Z', D', s')\); the household takes as given the laws of motion \(\tilde{X}' = \tilde{G}(X)\) and \(X' = G(X)\).
+
+## Job-Finding Probability and Aggregate Law of Motion
+
+Matches are created by a Cobb–Douglas matching function:
+
+\[
+M(\tilde{X}, V) = \gamma\bigl(U(\tilde{X}) + \lambda\, N(\tilde{X})\bigr)^{\alpha}\, V^{1-\alpha},
+\]
+
+so the job-finding rate is
+
+\[
+f(\tilde{X}) = \frac{M\bigl(\tilde{X},\, V(\tilde{X})\bigr)}{U(\tilde{X}) + \lambda\, N(\tilde{X})},
+\]
+
+where vacancies \(V(\tilde{X})\) satisfy a free-entry condition. Three aggregate mappings link the within- and across-period states:
+
+- \(X = \hat{G}(\tilde{X})\): pre-transition to post-transition (within period).
+- \(\tilde{X}' = \tilde{G}(X)\): post-transition to start of next period.
+- \(X' = G(X) = \hat{G}\bigl(\tilde{G}(X)\bigr)\): composite law of motion.
+
+Employment evolves as \(N = (1-\lambda)\,\tilde{N} + M(\tilde{X}, V)\), and the type distribution \(\mu\) updates through employment transitions and household saving decisions (equations 28–30 of the paper).
+
+## Perceived Law of Motion
+
+The household takes the aggregate laws of motion \(\tilde{X}' = \tilde{G}(X)\) and \(X' = G(X)\) as given. In practice these are approximated numerically using the method of Krusell and Smith (1998): the infinite-dimensional distribution \(\mu\) is summarized by a finite set of moments, and log-linear forecasting rules are estimated from simulated data. The paper does not specify the forecasting-rule functional form in the main text; details are in Appendix B.
+
+## Key Calibration Parameters
+
+From Tables 1–2 of the paper (one period = one quarter):
+
+| Parameter | Value | Description |
+|---|---|---|
+| \(\sigma\) | 1.5 | Relative risk aversion |
+| \(\beta\) | 0.966 | Time-discount factor |
+| \(\lambda\) | 0.10 | Exogenous separation rate |
+| \(b\) | 0.446 | UI benefit per efficiency unit |
+| \(\alpha\) | 0.60 | Matching elasticity (searchers) |
+| \(\gamma\) | 0.645 | Matching efficiency |
+| \(\bar{w}\) | 0.637 | Steady-state wage per eff. unit |
+| \(\varepsilon_w\) | 0.45 | Wage elasticity w.r.t. output |
+| \(\rho_D\) | 0.70 | Monetary-shock persistence |
+| \(\sigma_D\) | 6.25e-4 | Monetary-shock std. dev. |
+| \(\rho_Z\) | 0.95 | TFP persistence |
+| \(\sigma_Z\) | 0.006 | TFP std. dev. |
+| \(\rho_\Pi\) | 1.20 | Taylor-rule inflation response |
+| \(\bar{\Pi}\) | 1.005 | Inflation target (quarterly gross) |
+
+Borrowing constraint: \(a' \geq 0\) (no borrowing).

--- a/models/We-Would-Like-In-Econ-ARK/GKNMonetaryPolicyHA/docs/gkn-bellman-excerpt.md
+++ b/models/We-Would-Like-In-Econ-ARK/GKNMonetaryPolicyHA/docs/gkn-bellman-excerpt.md
@@ -230,3 +230,45 @@ From Tables 1–2 of the paper (one period = one quarter):
 | \(\bar{\Pi}\) | 1.005 | Inflation target (quarterly gross) |
 
 Borrowing constraint: \(a' \geq 0\) (no borrowing).
+
+---
+
+## Perch Decomposition
+
+The household problem admits a single-stage decomposition into three perches following the ADC (Arrival–Decision–Continuation) convention of SolvingMicroDSOPs §§12–13.
+
+### Stage overview
+
+Working backward from the end of the period:
+
+\[
+\boxed{v_{\succ}(e,s,a',X')}
+\;\xrightarrow{\;\mathbb{B}\;}\;
+\boxed{v(e,s,m,X')}
+\;\xrightarrow{\;\mathbb{I}\;}\;
+\boxed{v_{\prec}(e_{\text{old}},s_{\text{old}},a,X)}
+\]
+
+The full-period operator is \(\mathbb{T} = \mathbb{I} \circ \mathbb{B}\), closed by the identity \(v_{\succ} = v_{\prec}^{\text{next period}}\).
+
+### Perch table
+
+| Perch | Name | State variables | Value function | Control |
+|-------|------|-----------------|----------------|---------|
+| \(\prec\) | Arrival | \((e_{\text{old}}, s_{\text{old}}, a, X)\) | \(v_{\prec}(e_{\text{old}}, s_{\text{old}}, a, X)\) | — |
+| \(\circ\) | Decision | \((e, s, m, X')\) | \(v(e, s, m, X')\) | \(c\) |
+| \(\succ\) | Continuation | \((e, s, a', X')\) | \(v_{\succ}(e, s, a', X')\) | — |
+
+### Within-stage transitions
+
+| Transition | Direction | Mapping |
+|------------|-----------|---------|
+| \(\mathrm{g}_{\prec\circ}\) | Arrival → Decision | Draw \((e, s, Z', D')\); compute \(X' = H(X, Z', D')\); form \(m = (p_a(X') + d_a(X'))a + y(e,s,X')\). |
+| \(\mathrm{g}_{\circ\succ}\) | Decision → Continuation | \(a' = m - c\); \(e, s, X'\) pass through unchanged. |
+
+### Movers
+
+| Mover | Direction | Operation |
+|-------|-----------|-----------|
+| \(\mathbb{B}\) | Continuation → Decision (backward) | Pure optimization: \(v(e,s,m,X') = \max_{c \in [0,m]} \bigl\{ u(c) + \beta\, v_{\succ}(e,s,m-c,X') \bigr\}\). Solvable by EGM: invert \(c^{-\sigma} = \beta\, v'_{\succ}\) to get \(c^*(a') = (\beta\, v'_{\succ})^{-1/\sigma}\), then recover \(m^*(a') = a' + c^*(a')\). |
+| \(\mathbb{I}\) | Decision → Arrival (forward/integration) | Expectation over pre-decision shocks: \(v_{\prec}(e_{\text{old}}, s_{\text{old}}, a, X) = \mathbb{E}_{e,s,Z',D'}[v(e,s,m,X')]\). The shadow marginal value carries the return factor: \(v'_{\prec} = \mathbb{E}[(p_a(X') + d_a(X')) \cdot v'(e,s,m,X')]\). |

--- a/models/We-Would-Like-In-Econ-ARK/GKNMonetaryPolicyHA/docs/gkn-bellman-excerpt.md
+++ b/models/We-Would-Like-In-Econ-ARK/GKNMonetaryPolicyHA/docs/gkn-bellman-excerpt.md
@@ -2,6 +2,58 @@
 
 Faithful summary of the household dynamic program in Section 2 of the paper.
 
+## Comprehensive Symbol Table
+
+| Symbol | Role | Domain / Space | Description |
+|--------|------|----------------|-------------|
+| \(e\) | Individual state | \(\{0,1\}\) | Employment status (0 = unemployed, 1 = employed) |
+| \(s\) | Individual state | \(S = \{s_1, s_2, s_3, s_4\}\) | Household skill level |
+| \(a\) | Individual state | \(\mathbb{R}^+\) | Mutual-fund share holdings (beginning of period) |
+| \(e_{\text{old}}\) | Arrival-perch state | \(\{0,1\}\) | Pre-transition employment status |
+| \(s_{\text{old}}\) | Arrival-perch state | \(S\) | Pre-transition skill level |
+| \(X\) | Aggregate state (post-transition) | \(\mathbb{R}^{n_X}\) | \((K, N, Z, D, \mu)\) — capital, employment, TFP, monetary shock, distribution |
+| \(\tilde{X}\) | Aggregate state (pre-transition) | \(\mathbb{R}^{n_X}\) | \((K, \tilde{N}, Z, D, \tilde{\mu})\) — before separations and matching |
+| \(X'\) | Next-period aggregate state | \(\mathbb{R}^{n_X}\) | Post-transition aggregate state at \(t+1\) |
+| \(\tilde{X}'\) | Next-period pre-transition state | \(\mathbb{R}^{n_X}\) | Pre-transition aggregate state at \(t+1\) |
+| \(c\) | Control | \(\mathbb{R}^+\) | Consumption |
+| \(a'\) | Control / poststate | \(\mathbb{R}^+\) | Next-period mutual-fund shares (\(a' \geq 0\)) |
+| \(m\) | Derived (decision-perch) | \(\mathbb{R}^+\) | Market resources: \(m = (p_a + d_a)a + y(e,s,X')\) |
+| \(Z'\) | Exogenous shock | \(\mathbb{R}^+\) | Next-period TFP; AR(1) in logs |
+| \(D'\) | Exogenous shock | \(\mathbb{R}\) | Next-period monetary-policy shock; AR(1) in logs |
+| \(s'\) | Exogenous shock | \(S\) | Next-period skill; Markov chain with matrix \(\pi\) |
+| \(W(X,e,s,a)\) | Value function | \(\mathbb{R}\) | Full-problem value (paper's notation, eqs. 1 & 3) |
+| \(v(e,s,m,X')\) | Value function (decision perch) | \(\mathbb{R}\) | Stage-decomposed decision-perch value |
+| \(v_\prec(e_{\text{old}},s_{\text{old}},a,X)\) | Value function (arrival perch) | \(\mathbb{R}\) | Arrival-perch value (beginning of period) |
+| \(v_\succ(e,s,a',X')\) | Value function (continuation perch) | \(\mathbb{R}\) | Continuation-perch value (end of period) |
+| \(v'\), \(v'_\prec\) | Marginal value functions | \(\mathbb{R}\) | Derivatives w.r.t. \(m\) and \(a\) respectively |
+| \(u(c)\) | Utility | \(\mathbb{R}\) | Period utility: \(c^{1-\sigma}/(1-\sigma)\) (CRRA) |
+| \(p_a(X)\) | Price function | \(\mathbb{R}^+\) | Ex-dividend mutual-fund share price |
+| \(d_a(X)\) | Price function | \(\mathbb{R}^+\) | Dividends per mutual-fund share |
+| \(w(X)\) | Price function | \(\mathbb{R}^+\) | Wage per efficiency unit of labor |
+| \(\tau(X)\) | Price function | \([0,1]\) | Proportional payroll tax rate |
+| \(y(e,s,X)\) | Income map | \(\mathbb{R}^+\) | \(w(X)s(1-\tau(X))\) if \(e=1\); \(bs\) if \(e=0\) |
+| \(f(\tilde{X})\) | Matching function | \([0,1]\) | Job-finding probability (evaluated at pre-transition state) |
+| \(M(\tilde{X},V)\) | Matching function | \(\mathbb{R}^+\) | Cobb–Douglas aggregate matches |
+| \(H(X,Z',D')\) | Aggregate law of motion | \(\mathbb{R}^{n_X}\) | Krusell-Smith forecasting rule; \(X' = H(X,Z',D')\) |
+| \(\hat{G}(\tilde{X})\) | Aggregate transition | \(\mathbb{R}^{n_X}\) | Pre-transition → post-transition (within period) |
+| \(\tilde{G}(X)\) | Aggregate transition | \(\mathbb{R}^{n_X}\) | Post-transition → next pre-transition (across period) |
+| \(\sigma\) | Parameter | \(\mathbb{R}^+\) | Relative risk aversion (= 1.5) |
+| \(\beta\) | Parameter | \((0,1)\) | Time-discount factor (= 0.966) |
+| \(\lambda\) | Parameter | \([0,1]\) | Exogenous job-separation rate (= 0.10) |
+| \(b\) | Parameter | \(\mathbb{R}^+\) | UI benefit per efficiency unit (= 0.446) |
+| \(\alpha\) | Parameter | \([0,1]\) | Matching elasticity w.r.t. searchers (= 0.60) |
+| \(\gamma\) | Parameter | \(\mathbb{R}^+\) | Matching efficiency (= 0.645) |
+| \(\bar{w}\) | Parameter | \(\mathbb{R}^+\) | Steady-state wage per eff. unit (= 0.637) |
+| \(\varepsilon_w\) | Parameter | \(\mathbb{R}^+\) | Wage elasticity w.r.t. output (= 0.45) |
+| \(\rho_Z\) | Parameter | \([0,1)\) | TFP persistence (= 0.95) |
+| \(\sigma_Z\) | Parameter | \(\mathbb{R}^+\) | TFP innovation std. dev. (= 0.006) |
+| \(\rho_D\) | Parameter | \([0,1)\) | Monetary-shock persistence (= 0.70) |
+| \(\sigma_D\) | Parameter | \(\mathbb{R}^+\) | Monetary-shock std. dev. (= 6.25e-4) |
+| \(\rho_\Pi\) | Parameter | \(\mathbb{R}^+\) | Taylor-rule inflation response (= 1.20) |
+| \(\bar{\Pi}\) | Parameter | \(\mathbb{R}^+\) | Inflation target, quarterly gross (= 1.005) |
+| \(\pi_{s,s'}\) | Parameter (matrix) | \([0,1]^{4\times 4}\) | Skill transition matrix (Table 2) |
+| \(s_1,\ldots,s_4\) | Parameter (grid) | \(\mathbb{R}^+\) | Skill grid: \(\{0.123, 0.421, 1.435, 34.65\}\) |
+
 ## States
 
 **Aggregate state** (post labor-market transitions):

--- a/models/We-Would-Like-In-Econ-ARK/GKNMonetaryPolicyHA/docs/gkn-bellman-improved.md
+++ b/models/We-Would-Like-In-Econ-ARK/GKNMonetaryPolicyHA/docs/gkn-bellman-improved.md
@@ -1,0 +1,252 @@
+# GKN Household Problem: A Stage-Oriented Decomposition
+
+Source: Gornemann, Kuester, and Nakajima (2012), Section 2.
+
+## 1. The Full Problem
+
+A household with employment status \(e \in \{0,1\}\), skill \(s \in S\), and mutual-fund shares \(a \geq 0\) solves
+
+\[
+W(X, e, s, a) =
+\max_{c,\; a' \geq 0}
+\left\{
+\frac{c^{1-\sigma}}{1-\sigma}
++ \beta\,\mathbb{E}\!\left[
+  \pi^e_{1}(\tilde{X}')\, W(X', 1, s', a')
+  + \pi^e_{0}(\tilde{X}')\, W(X', 0, s', a')
+\right]
+\right\}
+\]
+
+subject to
+
+\[
+c + p_a(X)\,a' = \bigl(p_a(X) + d_a(X)\bigr)\,a + y(e, s, X),
+\]
+
+where \(\pi^e_1, \pi^e_0\) are the employment transition probabilities (defined in Section 4 below) and the expectation is over \((Z', D', s')\).
+
+The aggregate state is \(X = (K, N, Z, D, \mu)\). The paper distinguishes a pre-transition state \(\tilde{X}\) from the post-transition state \(X\); see Section 3.
+
+This section decomposes \(W\) into three sub-value functions — one at each perch — following a backward stage structure analogous to SolvingMicroDSOPs §12–13.
+
+---
+
+## 2. Stage Decomposition: Overview
+
+Working backward from the end of the period:
+
+\[
+\boxed{v_{\succ}(e,s,a',X')}
+\;\xrightarrow{\;\mathbb{B}\;}\;
+\boxed{v(e,s,m,X')}
+\;\xrightarrow{\;\mathbb{I}\;}\;
+\boxed{v_{\prec}(e_{\text{old}},s_{\text{old}},a,X)}
+\]
+
+| Stage | Perch | State | Operation |
+|---|---|---|---|
+| 3 → 2 | Continuation → Decision | \((e,s,a',X') \to (e,s,m,X')\) | \(\mathbb{B}\): optimize over \(c\) |
+| 2 → 1 | Decision → Arrival | \((e,s,m,X') \to (e_{\text{old}},s_{\text{old}},a,X)\) | \(\mathbb{I}\): integrate over shocks |
+
+The full-period operator is \(\mathbb{T} = \mathbb{I} \circ \mathbb{B}\), closed by the identity \(v_{\succ} = v_{\prec}^{\text{next period}}\).
+
+---
+
+## 3. Continuation Perch — \(v_{\succ}(e, s, a', X')\)
+
+**State:** \((e, s, a', X')\) — post-decision employment, skill, chosen shares, and next-period aggregate state.
+
+The continuation value is defined as the value of entering the next period:
+
+\[
+v_{\succ}(e, s, a', X') \;\equiv\; v_{\prec}^{\text{next}}(e, s, a', X').
+\]
+
+This is the "end-of-period" value function.  At this perch the household has already chosen \(a'\) and all current-period actions are complete.  The mapping to the next period's arrival is a rename: \(a' \to a\), \(X' \to X\), \(e \to e_{\text{old}}\), \(s \to s_{\text{old}}\).
+
+---
+
+## 4. Decision Perch — \(v(e, s, m, X')\)
+
+**State:** \((e, s, m, X')\) — realized employment, skill, market resources, and (post-transition) aggregate state.
+
+**Mover \(\mathbb{B}\)** (backward, from continuation to decision): a pure optimization, no integration.
+
+\[
+v(e, s, m, X') = \max_{c \in [0,\, m]}
+\left\{
+\frac{c^{1-\sigma}}{1-\sigma} + \beta\, v_{\succ}(e, s, m - c, X')
+\right\}
+\]
+
+**Transition** (decision → continuation):
+
+\[
+a' = m - c, \qquad e_{\text{post}} = e, \qquad s_{\text{post}} = s, \qquad X_{\text{post}} = X'.
+\]
+
+Employment and skill pass through unchanged — they are not chosen at this stage.
+
+### Solution via EGM
+
+The first-order condition \(c^{-\sigma} = \beta\, v'_{\succ}(e, s, a', X')\) can be inverted:
+
+\[
+c^{*}(a') = \bigl(\beta\, v'_{\succ}(e, s, a', X')\bigr)^{-1/\sigma}.
+\]
+
+The endogenous grid point for \(m\) is recovered from the budget identity:
+
+\[
+m^{*}(a') = a' + c^{*}(a').
+\]
+
+The envelope condition delivers the marginal value of resources:
+
+\[
+v'(e, s, m, X') = c^{-\sigma}.
+\]
+
+---
+
+## 5. Arrival Perch — \(v_{\prec}(e_{\text{old}}, s_{\text{old}}, a, X)\)
+
+**State:** \((e_{\text{old}}, s_{\text{old}}, a, X)\) — beginning-of-period employment, skill, share holdings, and pre-transition aggregate state.
+
+**Mover \(\mathbb{I}\)** (integration, from decision to arrival): expectation over all pre-decision shocks.
+
+\[
+v_{\prec}(e_{\text{old}}, s_{\text{old}}, a, X)
+= \mathbb{E}_{e, s, Z', D'}\!\Big[\,
+v\!\bigl(e,\; s,\; m(e, s, a, X'),\; X'\bigr)
+\Big]
+\]
+
+### 5.1 Shock draws
+
+| Variable | Draw | Distribution |
+|---|---|---|
+| \(e\) | Employment status | \(P_e(\cdot \mid e_{\text{old}}, \tilde{X}')\) — see below |
+| \(s\) | Skill level | \(\pi_{s_{\text{old}}, \cdot}\) — Markov chain, independent of \(e, X\) |
+| \(Z'\) | TFP | AR(1): \(\log Z' = (1-\rho_Z)\log\bar{Z} + \rho_Z\log Z + \varepsilon_Z\) |
+| \(D'\) | Monetary shock | AR(1): \(\log D' = \rho_D \log D + \varepsilon_D\) |
+
+### 5.2 Aggregate state transition
+
+After shocks draw, the aggregate state updates:
+
+\[
+X' = H(X, Z', D').
+\]
+
+In practice \(H\) is the Krusell-Smith log-linear forecasting rule approximating the full law of motion.
+
+### 5.3 Resource formation
+
+Market resources depend on employment status:
+
+\[
+m = \bigl(p_a(X') + d_a(X')\bigr)\,a + y(e, s, X'),
+\]
+
+where
+
+\[
+y(e, s, X') =
+\begin{cases}
+w(X')\,s\,\bigl(1 - \tau(X')\bigr) & \text{if } e = 1 \text{ (employed)}, \\
+b\,s & \text{if } e = 0 \text{ (unemployed)}.
+\end{cases}
+\]
+
+### 5.4 Shadow marginal value
+
+For EGM in a prior (or outer) problem, the marginal value of shares at the arrival perch is:
+
+\[
+v'_{\prec}(e_{\text{old}}, s_{\text{old}}, a, X)
+= \mathbb{E}_{e, s, Z', D'}\!\Big[
+\bigl(p_a(X') + d_a(X')\bigr)\, v'(e, s, m, X')
+\Big].
+\]
+
+The return factor \((p_a + d_a)\) enters via the chain rule on the budget constraint.
+
+---
+
+## 6. Employment Transitions
+
+The paper's within-period timing (Figure 1) generates the following transition probabilities, evaluated at the pre-transition aggregate state \(\tilde{X}'\) of the next period.
+
+**From employed** (\(e_{\text{old}} = 1\)):
+
+\[
+\Pr(e = 1 \mid e_{\text{old}}=1) = 1 - \lambda + \lambda\,f(\tilde{X}'), \qquad
+\Pr(e = 0 \mid e_{\text{old}}=1) = \lambda\bigl(1 - f(\tilde{X}')\bigr).
+\]
+
+An employed household is separated with probability \(\lambda\), but a separated household can immediately re-match with probability \(f(\tilde{X}')\).
+
+**From unemployed** (\(e_{\text{old}} = 0\)):
+
+\[
+\Pr(e = 1 \mid e_{\text{old}}=0) = f(\tilde{X}'), \qquad
+\Pr(e = 0 \mid e_{\text{old}}=0) = 1 - f(\tilde{X}').
+\]
+
+### Job-finding rate
+
+\[
+f(\tilde{X}) = \frac{\gamma\bigl(U(\tilde{X}) + \lambda N(\tilde{X})\bigr)^{\alpha}\, V(\tilde{X})^{1-\alpha}}{U(\tilde{X}) + \lambda N(\tilde{X})},
+\]
+
+where vacancies \(V(\tilde{X})\) satisfy a free-entry condition from the firm side.
+
+---
+
+## 7. Functional Forms and Calibration
+
+### Preferences
+
+\[
+u(c) = \frac{c^{1-\sigma}}{1-\sigma}, \qquad \sigma = 1.5, \quad \beta = 0.966.
+\]
+
+Labor supply is inelastic.
+
+### Skill grid and transition matrix
+
+Four levels \(s \in \{0.123,\; 0.421,\; 1.435,\; 34.65\}\).  Transition matrix (Table 2):
+
+\[
+\pi = \begin{pmatrix}
+0.9719 & 0.0275 & 0.0000 & 0.0006 \\
+0.0275 & 0.9444 & 0.0275 & 0.0006 \\
+0.0000 & 0.0275 & 0.9719 & 0.0006 \\
+0.0183 & 0.0183 & 0.0183 & 0.9450
+\end{pmatrix}.
+\]
+
+### Wage function
+
+\[
+\log w(X) - \log \bar{w} = \varepsilon_w\bigl(\log y(X) - \log\bar{y}\bigr), \qquad \varepsilon_w = 0.45,\; \bar{w} = 0.637.
+\]
+
+### Other parameters
+
+| Symbol | Value | Description |
+|---|---|---|
+| \(\lambda\) | 0.10 | Separation rate |
+| \(b\) | 0.446 | UI benefit per efficiency unit |
+| \(\alpha\) | 0.60 | Matching elasticity |
+| \(\gamma\) | 0.645 | Matching efficiency |
+| \(\rho_Z\) | 0.95 | TFP persistence |
+| \(\sigma_Z\) | 0.006 | TFP std. dev. |
+| \(\rho_D\) | 0.70 | Monetary-shock persistence |
+| \(\sigma_D\) | 6.25e-4 | Monetary-shock std. dev. |
+| \(\rho_\Pi\) | 1.20 | Taylor-rule inflation response |
+| \(\bar{\Pi}\) | 1.005 | Inflation target (quarterly gross) |
+
+Borrowing constraint: \(a' \geq 0\).

--- a/models/We-Would-Like-In-Econ-ARK/GKNMonetaryPolicyHA/docs/gkn-dolo.yaml
+++ b/models/We-Would-Like-In-Econ-ARK/GKNMonetaryPolicyHA/docs/gkn-dolo.yaml
@@ -33,8 +33,19 @@ symbols:
 
 equations:
   arvl_to_dcsn_transition: |
-    e ~ P_e(e_old, X)
+    # workaround: P_e should be evaluated at X_tilde_prime (the pre-transition
+    # aggregate state of the next period), not X. The paper (Section 2.3, Figure 1)
+    # is explicit: f = f(X_tilde'). The YAML uses X_tilde_prime to reflect this,
+    # but dolo-plus has no canonical idiom for distinguishing pre- vs post-transition
+    # aggregate states. See verification.md for details.
+    X_tilde_prime = G_tilde(X)
+    e ~ P_e(e_old, X_tilde_prime)
     s ~ P_s(s_old)
+    # unresolved: H is a Krusell-Smith log-linear forecasting rule approximating the
+    # full law of motion for X. The paper does not give a closed-form H; details are
+    # in Appendix B. The infinite-dimensional distribution mu is summarized by a
+    # finite set of moments with log-linear forecasting rules estimated from
+    # simulated data.
     X_prime = H(X, Z_prime, D_prime)
     y = e * w(X_prime) * s * (1 - tau(X_prime)) + (1 - e) * b_unemp * s
     m = (p_a(X_prime) + d_a(X_prime)) * a + y
@@ -62,6 +73,8 @@ equations:
       dV[<] = E_{e, s, Z_prime, D_prime}{(p_a(X_prime) + d_a(X_prime)) * dV}
 
   # Employment transition probabilities (Section 2.3 of the paper)
+  # workaround: These are evaluated at X_tilde' (pre-transition state of next
+  # period), not at X' (post-transition). See arvl_to_dcsn_transition above.
   # Employed:   P(e'=1 | e=1) = 1 - lambda + lambda * f(X_tilde')
   #             P(e'=0 | e=1) = lambda * (1 - f(X_tilde'))
   # Unemployed: P(e'=1 | e=0) = f(X_tilde')
@@ -92,6 +105,8 @@ calibration:
       - [0.0183, 0.0183, 0.0183, 0.9450]
 
   settings:
+    # placeholder: grid settings are reasonable defaults, not from the paper
+    # (which does not report grid sizes in the main text).
     n_a: 200
     a_min: 0.0
     a_max: 500.0

--- a/models/We-Would-Like-In-Econ-ARK/GKNMonetaryPolicyHA/docs/gkn-dolo.yaml
+++ b/models/We-Would-Like-In-Econ-ARK/GKNMonetaryPolicyHA/docs/gkn-dolo.yaml
@@ -1,0 +1,100 @@
+# GKN (2012) Household Problem — Dolo-Plus YAML
+# Gornemann, Kuester, Nakajima: Monetary Policy with Heterogeneous Agents
+# Generated via Matsya session topics2026-mon-policy
+
+name: gkn_household
+model_type: adc-stage
+
+symbols:
+  spaces:
+    E: '@def {0, 1}'
+    S: '@def {1, ..., n_s}'
+    Xa: '@def R+'
+    Xm: '@def R+'
+    XAgg: '@def R^n_X'
+
+  prestate:
+    e_old: '@in E'
+    s_old: '@in S'
+    a: '@in Xa'
+    X: '@in XAgg'
+
+  states:
+    e: '@in E'
+    s: '@in S'
+    m: '@in Xm'
+    X_prime: '@in XAgg'
+
+  poststates:
+    e_post: '@in E'
+    s_post: '@in S'
+    a_prime: '@in Xa'
+    X_post: '@in XAgg'
+
+equations:
+  arvl_to_dcsn_transition: |
+    e ~ P_e(e_old, X)
+    s ~ P_s(s_old)
+    X_prime = H(X, Z_prime, D_prime)
+    y = e * w(X_prime) * s * (1 - tau(X_prime)) + (1 - e) * b_unemp * s
+    m = (p_a(X_prime) + d_a(X_prime)) * a + y
+
+  dcsn_to_cntn_transition: |
+    a_prime = m - c
+    e_post = e
+    s_post = s
+    X_post = X_prime
+
+  cntn_to_dcsn_mover:
+    Bellman: |
+      V = max_{c}{c^(1 - sigma) / (1 - sigma) + beta * V[>]}
+    InvEuler: |
+      c[>] = (beta * dV[>])^(-1/sigma)
+    MarginalBellman: |
+      dV = c^(-sigma)
+    cntn_to_dcsn_transition: |
+      m[>] = a_prime + c[>]
+
+  dcsn_to_arvl_mover:
+    Bellman: |
+      V[<] = E_{e, s, Z_prime, D_prime}(V)
+    ShadowBellman: |
+      dV[<] = E_{e, s, Z_prime, D_prime}{(p_a(X_prime) + d_a(X_prime)) * dV}
+
+  # Employment transition probabilities (Section 2.3 of the paper)
+  # Employed:   P(e'=1 | e=1) = 1 - lambda + lambda * f(X_tilde')
+  #             P(e'=0 | e=1) = lambda * (1 - f(X_tilde'))
+  # Unemployed: P(e'=1 | e=0) = f(X_tilde')
+  #             P(e'=0 | e=0) = 1 - f(X_tilde')
+
+calibration:
+  parameters:
+    sigma: 1.5
+    beta: 0.966
+    lambda: 0.10
+    b_unemp: 0.446
+    alpha: 0.60
+    gamma_match: 0.645
+    w_bar: 0.637
+    eps_w: 0.45
+    rho_D: 0.70
+    sigma_D: 6.25e-4
+    rho_Z: 0.95
+    sigma_Z: 0.006
+    rho_Pi: 1.20
+    Pi_bar: 1.005
+    n_s: 4
+    s_grid: [0.123, 0.421, 1.435, 34.65]
+    P_s:
+      - [0.9719, 0.0275, 0.0000, 0.0006]
+      - [0.0275, 0.9444, 0.0275, 0.0006]
+      - [0.0000, 0.0275, 0.9719, 0.0006]
+      - [0.0183, 0.0183, 0.0183, 0.9450]
+
+  settings:
+    n_a: 200
+    a_min: 0.0
+    a_max: 500.0
+    n_X: 3
+    tol: 1.0e-6
+    max_iter: 1000

--- a/models/We-Would-Like-In-Econ-ARK/GKNMonetaryPolicyHA/docs/gkn-verification.md
+++ b/models/We-Would-Like-In-Econ-ARK/GKNMonetaryPolicyHA/docs/gkn-verification.md
@@ -1,0 +1,31 @@
+# Verification: Matsya Outputs vs. Source Paper
+
+Reference: Gornemann, Kuester, and Nakajima (2012), Section 2, equations (1)–(4), Tables 1–2.
+
+## What we accepted
+
+**Three-perch ADC decomposition.** Matsya's split into arrival \((e_\text{old}, s_\text{old}, a, X)\), decision \((e, s, m, X')\), and continuation \((e, s, a', X')\) is structurally sound. The paper's Bellman equations (1) and (3) separate cleanly into a pure optimization over \(c\) (the backward mover \(\mathbb{B}\)) and an expectation over next-period shocks (the integration mover \(\mathbb{I}\)). We accepted this decomposition without modification.
+
+**Mover placement.** Matsya correctly placed all stochastic transitions — employment, skill, TFP, monetary shock — in the arrival mover \(\mathbb{I}\), leaving the decision mover \(\mathbb{B}\) as a deterministic \(\max_c\). This matches the paper: consumption and saving are chosen *after* the household knows its employment status and the aggregate state (Section 2.2, Figure 1).
+
+**EGM structure.** The inverse Euler equation, endogenous grid recovery, and envelope condition in the YAML's `cntn_to_dcsn_mover` follow directly from the CRRA first-order condition in equation (1) and are standard.
+
+**Calibration block.** All parameter values (\(\sigma, \beta, \lambda, b, \alpha, \gamma, \rho_Z, \sigma_Z, \rho_D, \sigma_D, \rho_\Pi, \bar{\Pi}\)), the skill grid, and the \(4 \times 4\) transition matrix were verified against Tables 1 and 2 of the paper. However, **Matsya returned the skill transition matrix as a zero placeholder** — it could not retrieve the values from piped input — so we filled in the actual matrix from Table 2 by hand.
+
+## What we edited
+
+**Resource formation notation.** Matsya's first decomposition used the generic expression \(m = R(X')a + y(e,s,X')\). The paper uses mutual-fund shares, not a risk-free return. We corrected this to \(m = (p_a(X') + d_a(X'))a + y(e,s,X')\), matching the budget constraints in equations (2) and (4). Matsya's YAML draft (produced in a later call) used the correct notation.
+
+**Shadow marginal value.** The `dcsn_to_arvl_mover` ShadowBellman carries the factor \((p_a + d_a)\) through the expectation. Matsya produced this correctly in the YAML, but it was absent from the initial plain-text decomposition. We added it to the improved markdown (Section 5.4).
+
+**Timing of \(f(\tilde{X}')\).** Matsya's initial decomposition was ambiguous about whether the job-finding rate is evaluated at the pre-transition or post-transition aggregate state. The paper is explicit: \(f\) is a function of \(\tilde{X}'\) (the pre-transition state of the next period), not \(X'\). The YAML records the employment transition as `P_e(e_old, X)`, which conflates the two. The improved markdown and the YAML comments clarify that the argument is \(\tilde{X}'\).
+
+**Wage and tax in income function.** The YAML's `arvl_to_dcsn_transition` correctly uses `w(X_prime) * s * (1 - tau(X_prime))` for employed income. We verified this against equation (2): \(y(1,s,X) = w(X)s(1-\tau(X))\). The use of `X_prime` in the YAML (vs. \(X\) in the paper) reflects the stage decomposition's timing convention, where the decision-stage aggregate state has already been relabeled as \(X'\).
+
+## What we rejected or flagged
+
+**Piped-content retrieval.** Matsya's vector-store retrieval never ingested the piped excerpt. Across three attempts it returned only internal dolo-plus spec documents. This means Matsya's equations were reconstructed from conversation context and its training data, not directly from the paper. All equations were therefore cross-checked against the source before acceptance.
+
+**Generic `H(X, Z', D')` law of motion.** The YAML uses a black-box `H` for the aggregate transition. The paper solves this via Krusell-Smith log-linear forecasting rules (Appendix B), but does not give a closed-form \(H\) in the main text. We accepted `H` as a placeholder and noted the approximation method.
+
+**Grid settings.** Matsya proposed `n_a = 200`, `a_max = 500.0`, `n_X = 3` as computational settings. These are reasonable defaults but are not from the paper (which does not report grid sizes in the main text). We kept them as placeholders in the YAML `settings` block.

--- a/models/We-Would-Like-In-Econ-ARK/GKNMonetaryPolicyHA/docs/matsya-session.txt
+++ b/models/We-Would-Like-In-Econ-ARK/GKNMonetaryPolicyHA/docs/matsya-session.txt
@@ -1,0 +1,1 @@
+topics2026-mon-policy


### PR DESCRIPTION
## Summary

Formalize-and-finalize pass on the Gornemann, Kuester, and Nakajima (2012) ballpark item, following the [assignment #140 workflow](https://llorracc.github.io/workspace-course-topics/assignments/ask-ai-help-to-formalize-and-finalize-ballpark.html).

All changes scoped to `models/We-Would-Like-In-Econ-ARK/GKNMonetaryPolicyHA/`. No infrastructure files touched.

### What changed (5 commits)

| Commit | Round | Content |
|--------|-------|---------|
| `573340d` | 0 | Bring formalization artifacts from prior matsya work (bellman-excerpt, improved markdown, dolo-plus YAML, verification.md, matsya-session.txt) |
| `deacae2` | 2 | **Item 1:** Add comprehensive symbol table (~45 rows) to `bellman-excerpt.md` — required by CONTRIBUTING.md Formalized checklist |
| `220df47` | 3 | **Item 4:** Add perch decomposition section to `bellman-excerpt.md` — three perches, transitions, movers, stage operator — required by CONTRIBUTING.md |
| `78c2c2d` | 4 | **Items 3+5:** Fix `P_e` timing in YAML (was `P_e(e_old, X)`, now `P_e(e_old, X_tilde_prime)` matching paper Section 2.3) + add `# workaround:` / `# unresolved:` / `# placeholder:` inline flags per CONTRIBUTING.md convention |
| `d3d6710` | 5 | **Item 2:** Create `AGENTS.md` with all 6 required sections — required at Formalized tier |

---

## Prompt used (adapted from assignment template)

> Review the ballpark entry for Gornemann, Kuester, and Nakajima (2012) at `models/We-Would-Like-In-Econ-ARK/GKNMonetaryPolicyHA/` against the quality criteria in `CONTRIBUTING.md`. The entry has a legacy monolithic notebook, plus formalization-layer artifacts (bellman-excerpt, SMD-polished improved markdown, dolo-plus YAML, verification.md) in a `docs/` subfolder. I want a prioritized list of substantive changes to push the item toward and finalize it within the Formalized tier. Focus on the economics, the model statement, the formalization, and the AGENTS.md. Not cosmetic changes.

## Full model response — 5 proposed changes

### Item 1 — `bellman-excerpt.md` lacks the comprehensive symbol table required by CONTRIBUTING.md
- **Problem:** Symbol table entries were scattered across prose and partial tables; no unified comprehensive table.
- **Change:** Added ~45-row table with Symbol / Role / Domain / Description columns covering all objects.
- **File:** `docs/gkn-bellman-excerpt.md`

### Item 2 — No `AGENTS.md` (required at Formalized)
- **Problem:** No structured agent brief existed.
- **Change:** Created `AGENTS.md` with all 6 sections populated from grounded sources.
- **File:** `AGENTS.md`

### Item 3 — `P_e(e_old, X)` in YAML conflates pre- and post-transition aggregate state
- **Problem:** Paper is explicit that `f = f(X_tilde')` but YAML used `X`.
- **Change:** Added `X_tilde_prime = G_tilde(X)` and changed draw to `P_e(e_old, X_tilde_prime)`.
- **File:** `docs/gkn-dolo.yaml`

### Item 4 — `bellman-excerpt.md` missing explicit perch decomposition table
- **Problem:** Perch decomposition existed only in `gkn-bellman-improved.md`, not in the Matsya input document.
- **Change:** Added full perch table, transitions, movers, and stage operator.
- **File:** `docs/gkn-bellman-excerpt.md`

### Item 5 — YAML lacks `# workaround:` / `# unresolved:` inline flags
- **Problem:** CONTRIBUTING.md requires inline flags for non-canonical features.
- **Change:** Added flags for KS forecasting rule, P_e timing, and grid placeholders.
- **File:** `docs/gkn-dolo.yaml`

## Accept / edit / reject judgments

| # | Judgment | Reasoning |
|---|---------|-----------|
| 1 | **Accept** | CONTRIBUTING.md explicitly requires "comprehensive symbol table" at Formalized; the item had none. |
| 2 | **Accept** | AGENTS.md is required at Formalized tier; the item had none. |
| 3 | **Accept** | Economic correction flagged in verification.md but never implemented in the YAML. |
| 4 | **Accept** | CONTRIBUTING.md requires perch decomposition in bellman-excerpt.md specifically; it only existed in the polished variant. |
| 5 | **Accept** | CONTRIBUTING.md is explicit about the `# workaround:` convention; the YAML had informational comments but not the required flags. |

## Tier assessment

The formalization-layer files are now present and improved. The item's **exposition layer** still needs refactoring (monolithic notebook → four-notebook structure, `index.md`, bib files, `.mmd`) to fully qualify as Primer, which is a prerequisite for Formalized. Current effective tier: **between Draft and Primer** with formalization-layer work substantially advanced.

## Matsya session

`topics2026-mon-policy` (recorded in `docs/matsya-session.txt`).

## Test plan

- [ ] `gkn-dolo.yaml` parses as valid YAML
- [ ] `bellman-excerpt.md` contains a comprehensive symbol table (pipe-delimited rows with Symbol column)
- [ ] `bellman-excerpt.md` references all three perch names (arrival, decision, continuation)
- [ ] `AGENTS.md` contains the 6 required top-level sections
- [ ] All changes scoped to `models/We-Would-Like-In-Econ-ARK/GKNMonetaryPolicyHA/`


Made with [Cursor](https://cursor.com)