### PR TITLE
CONTRIBUTING: nudge ballpark exposition toward sophisticated readers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,8 @@ Four notebooks assembled by one `index.md`. Name them with the paper's citekey p
 | `<citekey>_summary.ipynb` | Non-technical motivation + findings overview (**required at Draft**), extended at Primer promotion with a **"The Model"** section stating the recursive formulation **explicitly**: no `u(c)` placeholders, explicit CRRA or EZ kernel, explicit bequest function, explicit transitions, explicit shock distributions, explicit constraint set. This "The Model" section is what the formalization layer will build on. |
 | `<citekey>_subsequent-literature.ipynb` | Research directions that followed the paper. Cite from `subsequent-literature.bib`. |
 
+**Audience and voice for `_intro.ipynb` and `_summary.ipynb`.** Write for a reader (PhD student or faculty researcher) who is deciding whether to invest 90 minutes in the paper itself. Two self-checks before submitting: (1) Does the first screen of `_summary.ipynb` give the paper's *headline quantitative result* — numbers, not adjectives? (2) Does it explain what makes the result credible — the identification strategy or theoretical mechanism, not just the methodology label? If either answer requires the reader to scroll past several paragraphs of prose to find, condense.
+
 The [Benhabib_et_al_2019](models/We-Would-Like-In-Econ-ARK/Benhabib_et_al_2019/) item is the reference instance of this layer.
 
 ### 2. Formalization layer — stretch (recommended for coursework)


### PR DESCRIPTION
## Summary

Adds one paragraph to the Exposition-layer section of `CONTRIBUTING.md` nudging contributors toward better-quality public-facing notebooks for sophisticated readers (PhD students, faculty researchers).

The paragraph poses two self-checks a contributor applies before submitting:
1. Does the first screen of `_summary.ipynb` give the paper's headline *quantitative* result — numbers, not adjectives?
2. Does it explain the *identification strategy or theoretical mechanism*, not just the methodology label?

## Why this and not a longer change

Reviewing the `Benhabib_et_al_2019` reference entry as a sophisticated reader who is deciding whether to spend 90 minutes on the paper, the gaps trace to a single absence in the spec: nothing tells contributors *what a good summary contains for that audience*. They default to a literature-review style that describes the paper but doesn't surface what makes it cite-worthy.

A more comprehensive revision (per-tier checklist of headline result, counterfactual table, identification paragraph, figure-above-the-fold, specific limitations, ...) was considered and rejected as too onerous. This single paragraph nudges contributor *thinking* without multiplying explicit requirements, new file types, new CI heuristics, or template fields.

## What this is NOT

- No new file requirements
- No new CI checks
- No new template fields in `index.md` frontmatter or `AGENTS.md`
- No reordering or restructuring of existing sections
- No retroactive obligation on existing entries

## Test plan

- [ ] CONTRIBUTING.md still renders cleanly on the MyST site after merge
- [ ] No CI checks reference content this paragraph would affect (it doesn't introduce any new checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
