### PR TITLE
CONTRIBUTING: require a 00-README.md orientation file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,10 +22,11 @@ A canonical ballpark item has three layers. The *exposition* layer is required; 
 
 ### 1. Exposition layer — required
 
-Four notebooks assembled by one `index.md`. Name them with the paper's citekey prefix, e.g. `benhabib2019_intro.ipynb`.
+Four notebooks assembled by one `index.md`, plus a `00-README.md` orientation file. Name the notebooks with the paper's citekey prefix, e.g. `benhabib2019_intro.ipynb`.
 
 | File | Content |
 |------|---------|
+| `00-README.md` | A short orientation file (sorts first in the directory listing via the `00-` prefix). Provides (1) a brief reading guide for any technical artifacts in the directory — for entries with the Formalization layer, name the conventions used (dolo-plus YAML format, the [Matsya](https://github.com/econ-ark/matsya) iteration loop that produced the YAMLs, inline `# unresolved:` flags), the excerpt-plus-YAML pairing pattern, and where the construction audit trail lives; (2) a one-line index of the main files in the directory. The intent is that a reader landing on the GitHub directory listing has enough orientation to choose what to read next. Keep it short — orientation only, not duplication. |
 | `index.md` | MyST page with `{include}` directives for the four notebooks below (in order), plus YAML frontmatter giving the rendered title. |
 | `<citekey>_intro.ipynb` | Full citation with DOI link. **Original ballpark author** (name + date). **Updated by** (latest + date). 3-sentence pitch: why the paper is in-ballpark for Econ-ARK. |
 | `<citekey>_prior-literature.ipynb` | Where the paper sits in the foundational literature (Bewley / Huggett / Aiyagari / de Nardi / ...). Use `{cite:t}` citations rendered from `references.bib`. |


### PR DESCRIPTION
## Summary

Adds a `00-README.md` row to the Exposition-layer table in `CONTRIBUTING.md`. The file provides:

1. A brief **reading guide** for any technical artifacts in the directory. For entries with the Formalization layer, names the conventions used: dolo-plus YAML format, the [Matsya](https://github.com/econ-ark/matsya) iteration loop that produced the YAMLs, inline `# unresolved:` flags, and the excerpt-plus-YAML pairing pattern.
2. A **one-line index** of the main files in the directory.

The `00-` prefix makes the file sort first in directory listings, so a reader landing on the GitHub view of the entry sees it before scanning the notebooks.

## Why this and not a longer change

A sophisticated reader (PhD student, faculty researcher) landing on the *directory view* — not the rendered MyST page — otherwise has to assemble the framing for the technical artifacts from multiple files. A single short orientation file closes that gap. No new template fields, no CI checks, no duplication of notebook content.

This complements the audience-and-voice nudge merged in PR #78 (which addresses the rendered-MyST-page reader) by also serving the directory-listing reader.

## Test plan

- [ ] CONTRIBUTING.md still renders cleanly on the MyST site
- [ ] Reference instance entry (Benhabib_et_al_2019) does NOT yet have a `00-README.md`; that's a follow-up to demonstrate the new requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)
