### PR TITLE
Rename 00-README.md to README.md (GFM, not MyST)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,11 +22,11 @@ A canonical ballpark item has three layers. The *exposition* layer is required; 
 
 ### 1. Exposition layer — required
 
-Four notebooks assembled by one `index.md`, plus a `00-README.md` orientation file. Name the notebooks with the paper's citekey prefix, e.g. `benhabib2019_intro.ipynb`.
+Four notebooks assembled by one `index.md`, plus a `README.md` orientation file. Name the notebooks with the paper's citekey prefix, e.g. `benhabib2019_intro.ipynb`.
 
 | File | Content |
 |------|---------|
-| `00-README.md` | A short orientation file (sorts first in the directory listing via the `00-` prefix). Provides (1) a brief reading guide for any technical artifacts in the directory — for entries with the Formalization layer, name the conventions used (dolo-plus YAML format, the [Matsya](https://github.com/econ-ark/matsya) iteration loop that produced the YAMLs, inline `# unresolved:` flags), the excerpt-plus-YAML pairing pattern, and where the construction audit trail lives; (2) a one-line index of the main files in the directory. The intent is that a reader landing on the GitHub directory listing has enough orientation to choose what to read next. Keep it short — orientation only, not duplication. |
+| `README.md` | A short orientation file. Written in **GitHub-flavored markdown** (not MyST) so GitHub auto-renders it inline below the directory listing for anyone landing on the GitHub view of the entry. Use Unicode for math (e.g. `Π_r`, `g(·;τ,r)`, `Π_τ ⊗ Π_r`, `c ≤ a`) rather than `$...$`. Provides (1) a brief reading guide for any technical artifacts in the directory — for entries with the Formalization layer, name the conventions used (dolo-plus YAML format, the [Matsya](https://github.com/econ-ark/matsya) iteration loop that produced the YAMLs, inline `# unresolved:` flags), the excerpt-plus-YAML pairing pattern, and where the construction audit trail lives; (2) a one-line index of the main files in the directory. The intent is that a reader landing on the GitHub directory listing has enough orientation to choose what to read next. Keep it short — orientation only, not duplication. |
 | `index.md` | MyST page with `{include}` directives for the four notebooks below (in order), plus YAML frontmatter giving the rendered title. |
 | `<citekey>_intro.ipynb` | Full citation with DOI link. **Original ballpark author** (name + date). **Updated by** (latest + date). 3-sentence pitch: why the paper is in-ballpark for Econ-ARK. |
 | `<citekey>_prior-literature.ipynb` | Where the paper sits in the foundational literature (Bewley / Huggett / Aiyagari / de Nardi / ...). Use `{cite:t}` citations rendered from `references.bib`. |

--- a/models/We-Would-Like-In-Econ-ARK/Benhabib_et_al_2019/README.md
+++ b/models/We-Would-Like-In-Econ-ARK/Benhabib_et_al_2019/README.md
@@ -10,12 +10,12 @@ The YAML files in this directory are written in **dolo-plus**, a modular-DP YAML
 
 Two parallel excerpt-plus-YAML pairs cover two layers of the model:
 
-- **Within-life** (one household's finite-horizon Bellman): [`bellman-excerpt.md`](bellman-excerpt.md) is the modular-DDSL Bellman statement (symbol table, perch decomposition, transitions, movers, EGM channel); [`dolo-plus-draft.yaml`](dolo-plus-draft.yaml) is the dolo-plus YAML, paper-calibrated from Tables 1, 4 plus the full $\Pi_r$ matrix from online Appendix C.1.
-- **Dynasty** (cross-generational composition): [`dynasty-excerpt.md`](dynasty-excerpt.md) describes the lifetime map $g(\cdot;\tau,r)$, the joint Markov chain $\Pi_\tau \otimes \Pi_r$, and the paper's Pareto-tail Proposition; [`dolo-plus-dynasty.yaml`](dolo-plus-dynasty.yaml) is the corresponding YAML.
+- **Within-life** (one household's finite-horizon Bellman): [`bellman-excerpt.md`](bellman-excerpt.md) is the modular-DDSL Bellman statement (symbol table, perch decomposition, transitions, movers, EGM channel); [`dolo-plus-draft.yaml`](dolo-plus-draft.yaml) is the dolo-plus YAML, paper-calibrated from Tables 1, 4 plus the full Π_r matrix from online Appendix C.1.
+- **Dynasty** (cross-generational composition): [`dynasty-excerpt.md`](dynasty-excerpt.md) describes the lifetime map g(·; τ, r), the joint Markov chain Π_τ ⊗ Π_r, and the paper's Pareto-tail Proposition; [`dolo-plus-dynasty.yaml`](dolo-plus-dynasty.yaml) is the corresponding YAML.
 
 Inline `# unresolved:` and `# SPECULATIVE` comments in the YAMLs flag places where the dolo-plus spec has no canonical idiom yet — the structural intent is paper-faithful even where keyword names may need to be renamed once the spec stabilizes.
 
-The construction audit trail lives in [`verification.md`](verification.md) (paragraph-level comparison against the published paper, including online Appendix A.1) and in `bellman-excerpt.md` Open Issues #1–#10 (chronological record of corrections, notably Issue #10 — where the published §I budget equation was found inconsistent with its own $c \le a$ constraint, and the online-Appendix-A.1 model was adopted instead).
+The construction audit trail lives in [`verification.md`](verification.md) (paragraph-level comparison against the published paper, including online Appendix A.1) and in `bellman-excerpt.md` Open Issues #1–#10 (chronological record of corrections, notably Issue #10 — where the published §I budget equation was found inconsistent with its own `c ≤ a` constraint, and the online-Appendix-A.1 model was adopted instead).
 
 ## Index of main files
 


### PR DESCRIPTION
## Summary

The orientation file added in PRs #81 (spec) and #82 (Benhabib reference instance) was named `00-README.md` and contained MyST-style LaTeX math (e.g. `$\Pi_r$`, `$g(\cdot;\tau,r)$`) that does not render correctly in GitHub's directory-listing inline preview.

This PR renames the file to `README.md` and replaces the LaTeX math with Unicode characters so the file renders under GFM.

## Why `README.md` and not a different `00-` prefix variant

GitHub auto-renders any file named `README.md` (or `README.rst`, etc.) inline below the directory listing — which is precisely the "reader landing on the GitHub directory listing" scenario the original spec targets. The `00-` prefix was meant to ensure the file sorts first; with `README.md`, GitHub's special handling makes it visible *regardless* of alphabetical sort.

## Changes

- **`CONTRIBUTING.md`** — Exposition-layer table now says `README.md` instead of `00-README.md`, with an explicit note that the file must be GitHub-flavored markdown (not MyST) and an example of using Unicode for math characters (`Π_r`, `g(·;τ,r)`, `Π_τ ⊗ Π_r`, `c ≤ a`).
- **`models/We-Would-Like-In-Econ-ARK/Benhabib_et_al_2019/`** — `00-README.md` renamed to `README.md`; LaTeX math replaced with Unicode equivalents.

## Test plan

- [ ] Browse to https://github.com/econ-ark/ballpark/tree/master/models/We-Would-Like-In-Econ-ARK/Benhabib_et_al_2019 after merge — `README.md` should render inline below the file listing
- [ ] Math symbols (`Π_r`, `Π_τ ⊗ Π_r`, `c ≤ a`) should display as plain Unicode characters, not as failed LaTeX
- [ ] Internal links to other files in the directory should work
- [ ] External links (DOI, Matsya repo) should resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)
