### PR TITLE
Benhabib: update entry-internal references to .mmd (now gitignored)

### DIFF
--- a/models/We-Would-Like-In-Econ-ARK/Benhabib_et_al_2019/AGENTS.md
+++ b/models/We-Would-Like-In-Econ-ARK/Benhabib_et_al_2019/AGENTS.md
@@ -13,7 +13,7 @@
 
 1. **Read first:** [`bellman-excerpt.md`](bellman-excerpt.md) — the modular-DDSL Bellman statement with comprehensive symbol table, perch decomposition, stage operators, and EGM channel. This is the authoritative formalization input; a YAML-drafting agent should read this before touching the notebooks.
 2. **For economic context beyond the formalization:** `Benhabib_et_al_2019_summary.ipynb` → "The Model".
-3. **Paper source for AI ingestion:** `Benhabib_et_al_2019.mmd` (Pandoc-converted). Prefer this over `Benhabib_et_al_2019.pdf`.
+3. **Paper source for AI ingestion:** access the paper via [DOI: 10.1257/aer.20151684](https://doi.org/10.1257/aer.20151684) (PDF not redistributed here, AER copyright). For AI-assisted reading, produce a local `Benhabib_et_al_2019.mmd` from the PDF via Mathpix or pandoc — this is gitignored, not committed (see repo-root `CONTRIBUTING.md` Asset-layer table).
 
 ## Formalization status
 
@@ -46,5 +46,5 @@
 ## Workflow reminders
 
 - **Matsya session:** use the course convention `topics2026-<slug>` for new work on this item.
-- **Paper verification:** Matsya output must be checked against the paper PDF (or `.mmd`), not only against the ballpark `_summary.ipynb` — the notebook is a summary with known simplifications.
+- **Paper verification:** Matsya output must be checked against the paper itself (access via the [DOI](https://doi.org/10.1257/aer.20151684), or against a locally-produced `.mmd` if the agent has produced one), not only against the ballpark `_summary.ipynb` — the notebook is a summary with known simplifications.
 - **When flagging workarounds in YAML:** use inline `# workaround:` or `# unresolved:` comments rather than silently fudging non-canonical syntax.

--- a/models/We-Would-Like-In-Econ-ARK/Benhabib_et_al_2019/README.md
+++ b/models/We-Would-Like-In-Econ-ARK/Benhabib_et_al_2019/README.md
@@ -38,7 +38,7 @@ The construction audit trail lives in [`verification.md`](verification.md) (para
 
 **Asset layer** (paper source material):
 
-- [`Benhabib_et_al_2019.mmd`](Benhabib_et_al_2019.mmd) — Pandoc-converted markdown of the paper, preferred over PDF for AI ingestion. The publisher-typeset PDF is **not** redistributed here for AER copyright reasons; access the paper via the [DOI](https://doi.org/10.1257/aer.20151684).
+- The paper PDF is **not** redistributed here for AER copyright reasons; access via the [DOI](https://doi.org/10.1257/aer.20151684). For AI-assisted reading, produce a local `Benhabib_et_al_2019.mmd` (Mathpix or pandoc conversion of the PDF) — this is gitignored at the repo root and not committed (see repo-root `CONTRIBUTING.md` Asset-layer table for the rationale).
 - [`fig1.png`](fig1.png), [`fig2.png`](fig2.png) — paper Figure 1 (life-cycle earnings profiles) and Figure 2 (wealth distribution).
 - [`references.bib`](references.bib), [`self.bib`](self.bib), [`subsequent-literature.bib`](subsequent-literature.bib) — bibliography (cited literature, the paper's own bib entry, and subsequent-literature citations respectively).
 

--- a/models/We-Would-Like-In-Econ-ARK/Benhabib_et_al_2019/verification.md
+++ b/models/We-Would-Like-In-Econ-ARK/Benhabib_et_al_2019/verification.md
@@ -6,7 +6,7 @@
 - Turn 5 (2026-04-27): self-assessment of paper-side gaps in the Turn-4 draft.
 - Turn 6 (2026-04-27): definitive syntax-status review of residual UNRESOLVED items.
 
-**Source compared:** published paper (`Benhabib_et_al_2019.mmd` / `.pdf`), §I (theoretical framework), §IIB (data sources), Table 1 (earnings), Table 4 (estimated parameters), and footnote 13 ($r$-chain off-diagonal structure).
+**Source compared:** the published paper itself (accessed via [DOI: 10.1257/aer.20151684](https://doi.org/10.1257/aer.20151684); a local Mathpix `.mmd` conversion was used during the comparison, but `.mmd` files are gitignored and not redistributed here). Sections compared: §I (theoretical framework), §IIB (data sources), Table 1 (earnings), Table 4 (estimated parameters), footnote 13 ($r$-chain off-diagonal structure), and online Appendix A.1 (numerical solution method) plus C.1 ($\Pi_r$ matrix).
 
 ## Accepted from matsya's YAML
 


### PR DESCRIPTION
## Summary

Cleans up entry-internal references to `Benhabib_et_al_2019.mmd` after PR #84 (gitignored `*.mmd`) and PR #85 (updated the spec). Three files in the entry referenced the `.mmd` as if it were committed — those references pointed to a file that's no longer in the directory.

## Changes

| File | Change |
|---|---|
| `README.md` (Asset-layer index) | Replaced the dead `[`Benhabib_et_al_2019.mmd`](Benhabib_et_al_2019.mmd)` link with a description of how to produce one locally (Mathpix or pandoc) and why it's not committed (copyright derivative). |
| `AGENTS.md` line 16 (Paper source for AI ingestion) | Rewritten to direct agents to access the paper via DOI and produce a local `.mmd` from it. |
| `AGENTS.md` line 49 (Paper verification reminder) | Rewritten to point at the DOI for the canonical paper, with `.mmd` as a locally-produced helper. |
| `verification.md` (Source compared) | Rewritten to credit the DOI paper as the source, with the local Mathpix `.mmd` mentioned as the working artifact (not redistributed). Bonus: the rewrite also adds online Appendix A.1 / C.1 to the listed sections-compared, which were used during the post-paper-review work in PRs #75/#79/#80. |

## Why this matters

A reader landing on the entry — especially via the rendered MyST page or the GitHub directory view — would have followed a dead link to `Benhabib_et_al_2019.mmd` and been confused. An agent reading `AGENTS.md` would have looked for a non-existent file. Both are now corrected to direct readers and agents to the DOI for the paper itself, with `.mmd` framed as a local-only AI ingestion convenience.

## Test plan

- [ ] `git grep 'Benhabib_et_al_2019\.mmd' models/We-Would-Like-In-Econ-ARK/Benhabib_et_al_2019/` returns no dead-link patterns; remaining references are descriptive (how to produce, where it goes).
- [ ] Internal links in README.md and AGENTS.md to other files in the directory still resolve.
- [ ] DOI links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
