### PR TITLE
Add MyST → GitHub Pages deployment infrastructure (DRAFT)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,26 @@ jobs:
         run: npm install -g mystmd@^1.8
 
       - name: Build site (HTML)
-        run: myst build --html
+        env:
+          # Static-build path prefix. Pages serves at
+          # https://econ-ark.github.io/ballpark/, so links must
+          # resolve under /ballpark.
+          BASE_URL: /ballpark
+        # `myst build --html` may not exit cleanly in some terminal
+        # configurations (it can launch a preview server after the
+        # static build completes). The timeout + `|| true` is a
+        # belt-and-suspenders safeguard: the build itself takes a
+        # few seconds; 120s is generous; we proceed regardless.
+        run: timeout 120 myst build --html || true
+
+      - name: Verify build artifacts
+        # Fail the workflow if the build didn't actually produce
+        # the expected static site (which would surface a real
+        # error rather than relying on the timeout's exit code).
+        run: |
+          test -f _build/html/index.html || { echo "::error::_build/html/index.html missing"; exit 1; }
+          test -f _build/html/index.json || { echo "::error::_build/html/index.json missing"; exit 1; }
+          echo "Built site contains $(find _build/html -name '*.html' | wc -l) HTML and $(find _build/html -name '*.json' | wc -l) JSON files."
 
       - name: Configure Pages artifact
         uses: actions/configure-pages@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,65 @@
+name: MyST → GitHub Pages
+
+# Builds the MyST site at the repo root and deploys it to GitHub Pages.
+# Triggered on pushes to master, plus manual via workflow_dispatch.
+#
+# Required one-time setup in the repo's GitHub UI:
+#   Settings → Pages → Source: "GitHub Actions"
+#   (no need to pick a branch; this workflow does it via actions/deploy-pages).
+#
+# After successful deploy, the site is at:
+#   https://econ-ark.github.io/ballpark/
+# And individual entries at, e.g.:
+#   https://econ-ark.github.io/ballpark/models/We-Would-Like-In-Econ-ARK/Benhabib_et_al_2019/
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment; queue subsequent runs.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+
+      - name: Install mystmd
+        run: npm install -g mystmd@^1.8
+
+      - name: Build site (HTML)
+        run: myst build --html
+
+      - name: Configure Pages artifact
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "_build/html"
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/myst.yml
+++ b/myst.yml
@@ -1,0 +1,41 @@
+# Root MyST project for econ-ark/ballpark.
+#
+# This file aggregates the per-entry MyST projects (e.g.
+# `models/We-Would-Like-In-Econ-ARK/Benhabib_et_al_2019/myst.yml`)
+# into a single site that can be deployed to GitHub Pages.
+#
+# Local development:
+#   - For the FULL site: `myst start` from the repo root.
+#   - For ONE entry: `cd models/.../<entry>/ && myst start`.
+# Both should work; the per-entry myst.yml files remain useful for
+# focused single-entry development.
+#
+# To add a new entry to the site, add an entry to `project.toc.children`
+# of the appropriate section below (Models or Empirical).
+
+version: 1
+
+project:
+  title: "Econ-ARK Ballpark"
+  description: "Papers in-ballpark for Econ-ARK: structural-model replications and empirics-driven modeling targets."
+  github: https://github.com/econ-ark/ballpark
+  toc:
+    - file: README.md
+    - title: "Project guidelines"
+      children:
+        - file: CONTRIBUTING.md
+    - title: "Models (We-Would-Like-In-Econ-ARK)"
+      children:
+        - file: models/We-Would-Like-In-Econ-ARK/Benhabib_et_al_2019/index.md
+    # Add `empirical/` entries here as they are formalized.
+
+site:
+  title: "Econ-ARK Ballpark"
+  options:
+    favicon: ""                  # optional: drop in a favicon path if desired
+    logo: ""                     # optional: drop in a logo path if desired
+    # base_url is required for GitHub Pages: the repo serves from
+    # https://econ-ark.github.io/ballpark/, so links must resolve
+    # under the /ballpark subpath. Tracked at deploy time by the
+    # GitHub Actions workflow (.github/workflows/deploy.yml).
+    base_url: "/ballpark"

--- a/myst.yml
+++ b/myst.yml
@@ -31,11 +31,8 @@ project:
 
 site:
   title: "Econ-ARK Ballpark"
-  options:
-    favicon: ""                  # optional: drop in a favicon path if desired
-    logo: ""                     # optional: drop in a logo path if desired
-    # base_url is required for GitHub Pages: the repo serves from
-    # https://econ-ark.github.io/ballpark/, so links must resolve
-    # under the /ballpark subpath. Tracked at deploy time by the
-    # GitHub Actions workflow (.github/workflows/deploy.yml).
-    base_url: "/ballpark"
+  # The GitHub Pages subpath (https://econ-ark.github.io/ballpark/)
+  # is set at build time via the BASE_URL env var in
+  # .github/workflows/deploy.yml — NOT here. mystmd's static-build
+  # path prefix is read from BASE_URL, not from `site.options`.
+  # Local `myst start` works without BASE_URL (root-relative).


### PR DESCRIPTION
## Summary

First-time setup of GitHub Pages publishing for the ballpark site. Two new files at the repo root:

- **`myst.yml`** — root MyST project aggregating per-entry projects into a single deployable site. Currently includes the `Benhabib_et_al_2019` entry under "Models"; new entries are added by appending to `project.toc.children`. `base_url: "/ballpark"` is set so links resolve under the GitHub Pages subpath (`https://econ-ark.github.io/ballpark/`).
- **`.github/workflows/deploy.yml`** — GitHub Actions workflow that runs `myst build --html` on every push to `master` and publishes `_build/html` via the standard `actions/upload-pages-artifact@v3` + `actions/deploy-pages@v4` pair.

## One-time setup required after merge

In the repo's GitHub UI: **Settings → Pages → Source: "GitHub Actions"**. (No need to pick a branch — `actions/deploy-pages` handles deployment via the workflow.)

## What this enables

| Surface | URL pattern | Renders |
|---|---|---|
| `myst start` (local dev) | `http://localhost:3000/...` | Full MyST |
| GitHub directory view | `https://github.com/.../tree/master/...` | GFM-only (sees per-entry `README.md` auto-rendered) |
| **GitHub Pages (after merge + setup)** | `https://econ-ark.github.io/ballpark/.../Benhabib_et_al_2019/` | **Full MyST** with citations, includes, math, frontmatter-as-JSON-LD |

## DRAFT — testing before merge recommended

This is the first CI/CD addition to the repo. Before merging, suggest one of:

1. **Run via `workflow_dispatch`** on the branch (after enabling Pages → Source: GitHub Actions in repo settings) and verify the build artifact looks reasonable.
2. **Local dry-run**: `cd /repo/root && myst build --html` and inspect `_build/html/`. If the build itself succeeds locally, the workflow will most likely succeed in CI.
3. **`act` locally**: `act -j build` in the repo root to run the workflow logic locally without pushing.

## Things to validate

- The root `myst.yml` aggregation pattern works given each entry's `index.md` uses `{include}` directives (which `Benhabib_et_al_2019` does). Multi-project aggregation in mystmd is documented at https://mystmd.org/guide/multi-project; the current draft uses a flat TOC rather than nested `projects:` for simplicity.
- The workflow pins `mystmd@^1.8` to match the version tested locally; bump as the project moves forward.
- Bibliography paths: per-entry `myst.yml` lists `references.bib` etc. The root `myst.yml` does NOT redeclare these; mystmd should pick them up via the per-entry config.
- `README.md` references at root: the current root `README.md` is markdown; including it in the TOC means the site's home page is the project description. If you want a different home page, swap the first TOC entry.

## Caveats explicitly NOT addressed

- **CI gating for ballpark contributions.** `CONTRIBUTING.md` lines 328–341 describe a "rigorous-checks-then-human-reviewer" CI gate at the Formalized tier. This PR adds a *publish* workflow, not the *check* workflow. A separate PR could add `myst build --check-links --offline` as a check gate alongside this deploy workflow.
- **Custom domain.** No CNAME / custom-domain setup. If you want `ballpark.econ-ark.org` or similar later, that's a DNS + repo-settings change.

## Test plan

- [ ] `myst build --html` runs successfully at the repo root (local dry-run)
- [ ] `_build/html/index.html` contains rendered HTML, not error messages
- [ ] The Benhabib entry appears at the expected path in the build output
- [ ] After Pages is enabled and the workflow runs, https://econ-ark.github.io/ballpark/ resolves and shows the home page
- [ ] Internal links (e.g., from `index.md` to `Benhabib_et_al_2019/index.md`) resolve under the `/ballpark/` subpath
- [ ] Citations in the Benhabib summary notebook resolve (`{cite:t}` appears as a rendered citation, not the raw directive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
