### PR TITLE
deploy.yml: SPA 404 fallback + opt into Node.js 24

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,15 @@ on:
     branches: [master]
   workflow_dispatch:
 
+# Opt JavaScript actions onto Node.js 24 ahead of GitHub's default
+# switchover (currently scheduled for 2026-06-02). Without this, actions
+# like actions/checkout, actions/setup-node, actions/configure-pages,
+# actions/upload-pages-artifact, actions/deploy-pages emit deprecation
+# warnings on every run. The Node.js *runtime* used for our script
+# steps (running mystmd) is set independently via actions/setup-node.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
   pages: write
@@ -63,6 +72,16 @@ jobs:
           test -f _build/html/index.html || { echo "::error::_build/html/index.html missing"; exit 1; }
           test -f _build/html/index.json || { echo "::error::_build/html/index.json missing"; exit 1; }
           echo "Built site contains $(find _build/html -name '*.html' | wc -l) HTML and $(find _build/html -name '*.json' | wc -l) JSON files."
+
+      - name: SPA 404 fallback (copy index.html → 404.html)
+        # mystmd's Book Theme is a single-page app: only index.html
+        # is produced; sub-page routing is client-side via JS that
+        # loads JSON. GitHub Pages otherwise returns a stock 404 for
+        # any deep link (e.g. /models/.../Benhabib_et_al_2019/),
+        # breaking shared URLs. Pages serves 404.html as the fallback
+        # for any unresolved path; bootstrapping the SPA from there
+        # lets it read the URL and route correctly client-side.
+        run: cp _build/html/index.html _build/html/404.html
 
       - name: Configure Pages artifact
         uses: actions/configure-pages@v5


### PR DESCRIPTION
## Summary

Two small follow-up fixes after PR #87's first successful Pages deploy:

1. **SPA 404 fallback.** mystmd's Book Theme is a single-page app: only `index.html` is produced; sub-page routing is client-side via JavaScript loading JSON. GitHub Pages otherwise returns a stock 404 for any deep link (e.g. `/models/We-Would-Like-In-Econ-ARK/Benhabib_et_al_2019/`), breaking shared URLs. The standard SPA-on-Pages fix: serve `404.html` (which Pages returns for any unresolved path) as a copy of `index.html`. The SPA boots from there, reads `window.location`, and client-side-routes correctly. One-line build step:

   ```yaml
   - name: SPA 404 fallback (copy index.html → 404.html)
     run: cp _build/html/index.html _build/html/404.html
   ```

2. **Node.js 24 opt-in.** The first run logged deprecation warnings for `actions/checkout@v4`, `actions/setup-node@v4`, `actions/configure-pages@v5`, `actions/upload-pages-artifact@v3`, `actions/deploy-pages@v4` — all currently running on Node.js 20 (which GitHub forces to Node.js 24 by default on **2026-06-02** and removes **2026-09-16**). Adding workflow-level `env: FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` opts these JS actions onto Node.js 24 immediately, eliminating the warnings and removing the surprise on the cutover date.

   This is independent of the Node.js *runtime* used for script steps (running mystmd) — that's still Node 20 via `actions/setup-node`'s `node-version: '20.x'`. The env var affects only how JS actions themselves run.

## Test plan

After merge, the next push to master should:

- [ ] Build, verify, and deploy succeed (same as PR #87)
- [ ] No "Node.js 20 deprecation" warnings in the run summary
- [ ] `https://econ-ark.github.io/ballpark/` resolves (root, was already working)
- [ ] `https://econ-ark.github.io/ballpark/models/We-Would-Like-In-Econ-ARK/Benhabib_et_al_2019/` resolves with HTTP 200 (was 404 before; the SPA bootstraps via `404.html` and routes to the entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
